### PR TITLE
[flask,express,spring-boot] Nicer SQL queries w pg_sleep() later in the query

### DIFF
--- a/express/db.js
+++ b/express/db.js
@@ -15,7 +15,7 @@ const getProducts = async function() {
       .getScope()
       .getTransaction();
     let span = transaction.startChild({ op: 'getproducts', description: 'db.query'});
-    const productsQuery = `SELECT *, pg_sleep(${sleepTime}) FROM products`;
+    const productsQuery = `SELECT * FROM products WHERE id IN (SELECT id from products, pg_sleep(${sleepTime}))`;
     const subspan = span.startChild({op: 'fetch products', description: productsQuery});
 
     const products = await knex.raw(productsQuery)
@@ -32,7 +32,7 @@ const getProducts = async function() {
     span = transaction.startChild({ op: 'getproducts.reviews', description: 'db.query'});
     let formattedProducts = [];
     for(product of products.rows) {
-      const reviewsQuery = `SELECT *, pg_sleep(0.25) FROM reviews WHERE productId = ${product.id}`;
+      const reviewsQuery = `SELECT * FROM reviews WHERE productId = ${product.id} AND id IN (SELECT id from reviews, pg_sleep(0.25))`;
       const subspan = span.startChild({op: 'fetch review', description: reviewsQuery});
       const retrievedReviews = await knex.raw(reviewsQuery);
       let productWithReviews = product;

--- a/flask/src/db.py
+++ b/flask/src/db.py
@@ -48,11 +48,11 @@ def get_products():
 
         n = weighter(operator.le, 12)
         products = connection.execute(
-            "SELECT *, pg_sleep(%s) FROM products" % (n)
+            "SELECT * FROM products WHERE id IN (SELECT id from products, pg_sleep(%s))" % (n)
         ).fetchall()
 
         for product in products:
-            query = text("SELECT *, pg_sleep(0.0625) FROM reviews WHERE productId = :x")
+            query = text("SELECT * FROM reviews WHERE productId = :x AND id IN (SELECT id from reviews, pg_sleep(0.0625))")
             reviews = connection.execute(query, x=product.id).fetchall()
 
             result = dict(product)

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/DatabaseHelper.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/DatabaseHelper.java
@@ -53,7 +53,7 @@ public class DatabaseHelper {
 	}
 
 	public List<Review> mapAllReviews(int productId, ISpan span) {		
-		String sql = "SELECT *, pg_sleep(0.25) FROM reviews WHERE productId = " + String.valueOf(productId);
+		String sql = "SELECT * FROM reviews WHERE productId = " + String.valueOf(productId) + " AND id IN (SELECT id from reviews, pg_sleep(0.25))";
 
 		ISpan sqlSpan = span.startChild("db", sql);
 		List<Review> allReviews = jdbcTemplate.query(sql, (rs, rowNum) -> new Review(rs.getInt("id"), rs.getInt("productid"),


### PR DESCRIPTION
Hopefully this doesn't have any significant effect on DB load, but we'll find out.

Another option would have been:
`select *, pg_sleep(0.0625) from products` -> `select * from products, pg_sleep(0.0625)`

# Testing
plugged every query into `psql` and made sure it returns something and doesn't fail.