### PR TITLE
[flask] fix pg_sleep that's too short after moving it out of SELECT

### DIFF
--- a/flask/src/db.py
+++ b/flask/src/db.py
@@ -14,6 +14,7 @@ USERNAME = os.getenv("DB_USERNAME")
 PASSWORD = os.getenv("DB_PASSWORD")
 FLASK_ENV = os.environ.get("FLASK_ENV")
 CLOUD_SQL_CONNECTION_NAME = os.environ.get("DB_CLOUD_SQL_CONNECTION_NAME")
+PRODUCTS_NUM = 4;
 
 class DatabaseConnectionError (Exception):
     pass
@@ -47,6 +48,9 @@ def get_products():
             connection = db.connect()
 
         n = weighter(operator.le, 12)
+        # adjust by number of products to get the same timeout as we had in the past
+        # before pg_sleep() was moved out of SELECT clause.
+        n *= PRODUCTS_NUM; 
         products = connection.execute(
             "SELECT * FROM products WHERE id IN (SELECT id from products, pg_sleep(%s))" % (n)
         ).fetchall()


### PR DESCRIPTION
In addition to this code change also changing following in DB:

```
DROP VIEW product_bundles, backorder_inventory, weekly_promotions;
CREATE VIEW product_bundles AS SELECT CAST(pg_sleep(0.391) as TEXT);
CREATE VIEW backorder_inventory AS SELECT CAST(pg_sleep(0.8) as TEXT);
CREATE VIEW weekly_promotions AS SELECT CAST(pg_sleep(1.563) as TEXT);
```

FROM products: multiply timeout by 4 (number of products)
FROM reviews: multiply timeout by 6.25 (average number of reviews per product)

# Testing
```
./deploy.sh --env=local react flask
```
http://localhost:3000/products