### PR TITLE
Add breadcrumbs for aspnet core

### DIFF
--- a/aspnetcore/AppMiddleware.cs
+++ b/aspnetcore/AppMiddleware.cs
@@ -7,14 +7,18 @@ namespace Empower.Backend;
 public class AppMiddleware
 {
     private readonly RequestDelegate _next;
+    private readonly ILogger<AppMiddleware> _logger;
 
-    public AppMiddleware(RequestDelegate next)
+    public AppMiddleware(RequestDelegate next, ILogger<AppMiddleware> logger)
     {
         _next = next;
+        _logger = logger;
     }
 
     public async Task InvokeAsync(HttpContext context)
     {
+        _logger.LogInformation("Running custom middleware.");
+        
         var headers = context.Request.Headers;
         
         var se = (string?) headers["se"];

--- a/aspnetcore/Empower.Backend.csproj
+++ b/aspnetcore/Empower.Backend.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.33.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/appsettings.json
+++ b/aspnetcore/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
- Switch from warning to info logging of default messages emitted by the framework.  This will get us some built-in breadcrumbs.
- Add a custom log message to the middleware component.
- Bump to latest Sentry.NET SDK version