### PR TITLE
Move slowness to interceptor

### DIFF
--- a/aspnetcore/Controllers/ProductsController.cs
+++ b/aspnetcore/Controllers/ProductsController.cs
@@ -30,9 +30,6 @@ public class ProductsController : ControllerBase
     {
         var span = SentrySdk.GetSpan()?.StartChild("/products.get_products", "function");
 
-        // just for demoing slowness
-        await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(1, 7)));
-        
         var products = await _dbContext.Products
             .Include(e => e.Reviews)
             .ToListAsync();

--- a/aspnetcore/HardwareStoreContext.cs
+++ b/aspnetcore/HardwareStoreContext.cs
@@ -1,3 +1,6 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
 namespace Empower.Backend;
 
 public class HardwareStoreContext : DbContext
@@ -111,5 +114,20 @@ public class HardwareStoreContext : DbContext
                 .HasColumnName("type")
                 .HasColumnType("character varying");
         });
+    }
+}
+
+public class DemoCommandInterceptor : DbCommandInterceptor
+{
+    public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        // for demoing slowness of db query
+        await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(1, 3)), cancellationToken);
+        
+        return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
     }
 }

--- a/aspnetcore/Program.cs
+++ b/aspnetcore/Program.cs
@@ -23,6 +23,8 @@ builder.Services.AddDbContext<HardwareStoreContext>(options =>
 {
     var connectionString = AppUtils.GetConnectionString(builder.Configuration);
     options.UseNpgsql(connectionString);
+
+    options.AddInterceptors(new DemoCommandInterceptor());
 });
 
 // Initialize Sentry.


### PR DESCRIPTION
Revise #230  - Do the slowness in a DB interceptor so it looks like the query was slow, rather than a delay before the query.