### PR TITLE
add method to route handler

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -89,30 +89,7 @@ Sentry.init({
   includeLocalVariables: true
 })
 
-// The Sentry request handler must be the first middleware on the app
-app.use(Sentry.Handlers.requestHandler());
-
-// TracingHandler creates a trace for every incoming request
-app.use(Sentry.Handlers.tracingHandler());
-
-app.use(cors());
-app.use(express.urlencoded({extended: true}));
-app.use(express.json());
-app.use(sentryEventContext);
-
-// Configure ENV
-require('dotenv').config();
-
-app.get('/', (req, res) => {
-  res.send('Sentry Express Service says Hello - turn me into a microservice that powers Payments, Shipping, or Customers');
-});
-
-app.get('/success', (req, res) => {
-  console.log("> success")
-  res.send(`success from express`);
-});
-
-app.get('/products', async (req, res) => {
+async function fetchProducts(req, res){
   try {
     // This /api call must happen before the DB.products() call or else it's a broken subtrace (if you do it after DB.Products())
     await axios.get(RUBY_BACKEND + "/api", {headers: headers} )
@@ -144,7 +121,32 @@ app.get('/products', async (req, res) => {
     Sentry.captureException(error);
     throw(error);
   }
+}
+
+// The Sentry request handler must be the first middleware on the app
+app.use(Sentry.Handlers.requestHandler());
+
+// TracingHandler creates a trace for every incoming request
+app.use(Sentry.Handlers.tracingHandler());
+
+app.use(cors());
+app.use(express.urlencoded({extended: true}));
+app.use(express.json());
+app.use(sentryEventContext);
+
+// Configure ENV
+require('dotenv').config();
+
+app.get('/', (req, res) => {
+  res.send('Sentry Express Service says Hello - turn me into a microservice that powers Payments, Shipping, or Customers');
 });
+
+app.get('/success', (req, res) => {
+  console.log("> success")
+  res.send(`success from express`);
+});
+
+app.get('/products', fetchProducts);
 
 app.get('/products-join', async(req, res) => {
   try {


### PR DESCRIPTION
Fix unknown frame in express backend profiles

The express backend displays an unknown frame right before the getIterator frame. This is because that frame is coming from the /products route handler. 
So we need to explicitly define and call a method to handle the logic so that the profiler can pick up the name of the frame

[profile before](https://sergios-test-org.sentry.io/profiling/profile/express-backend/a99f9908cb8143d39485b758eac84edb/flamechart/?colorCoding=by+system+vs+application+frame&query=&sorting=call+order&tid=0&view=top+down)

[profile after](https://sergios-test-org.sentry.io/profiling/profile/express-backend/ba98adeff8124fb7a1b4eace8e336c5a/flamechart/?colorCoding=by+system+vs+application+frame&fov=0%2C0%2C13795618816%2C24&query=&sorting=call+order&tid=0&view=top+down)