### PR TITLE
[platform] Script + GH workflow to auto cleanup inactive GAE resources

### DIFF
--- a/.github/workflows/cleanup_inactive_cloud_resources.yml
+++ b/.github/workflows/cleanup_inactive_cloud_resources.yml
@@ -1,0 +1,60 @@
+name: Deploy to Google App Engine upon commit to master branch and on schedule at midnight UTC
+run-name: Deployment triggered by ${{ github.event_name }} / ${{ github.actor }}
+
+on:
+  schedule:
+    - cron:  '0 0 * * *' # every day at midnight UTC 
+    # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+  workflow_dispatch:
+
+# Only run 1 workflow at a time. If new one starts abort any that are already running.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  default-job:
+    if: github.repository_owner == 'sentry-demos' # don't run in forks
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check out this repository code
+        uses: actions/checkout@v3
+        with:
+          path: empower
+          fetch-depth: 0
+        
+      - name: Check out `empower-config` to get env-config
+        uses: actions/checkout@v3
+        with:
+          repository: sentry-demos/empower-config
+          path: empower-config
+          token: ${{ secrets.KOSTY_PERSONAL_ACCESS_TOKEN_FOR_SYNC_DEPLOY_FORK }}
+          
+      - name: Get GCP_ env variables from empower-config/.gcloudrc
+        run: |
+          source empower-config/.gcloudrc 
+          echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$GCP_WORKLOAD_IDENTITY_PROVIDER" >> $GITHUB_OUTPUT
+          echo "GCP_SERVICE_ACCOUNT=$GCP_SERVICE_ACCOUNT" >> $GITHUB_OUTPUT 
+        id: gcloudrc
+        
+      - id: 'auth'
+        name: 'Authenticate Google Cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          workload_identity_provider: ${{ steps.gcloudrc.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ steps.gcloudrc.outputs.GCP_SERVICE_ACCOUNT }}
+
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+        
+      - name: Run cleanup scripts (more agressive for Flex instances)
+        run: |
+          bin/cleanup_inactive_cloud_resources.sh --project sales-engineering-sf --max-inactive-time-hours 336 
+          bin/cleanup_inactive_cloud_resources.sh --project sales-engineering-sf --max-inactive-time-hours 48 --flexible-only
+        working-directory: ./empower
+          
+      - run: echo "Job status is ${{ job.status }}."

--- a/.github/workflows/cleanup_inactive_cloud_resources.yml
+++ b/.github/workflows/cleanup_inactive_cloud_resources.yml
@@ -51,10 +51,12 @@ jobs:
       - name: 'Set up Google Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
         
+      # TODO: instead of hardcoding generate EXCLUDE list dynamically based on directory names (once naming is standardized)
       - name: Run cleanup scripts (more agressive for Flex instances)
         run: |
-          bin/cleanup_inactive_cloud_resources.sh --project sales-engineering-sf --max-inactive-time-hours 336 
-          bin/cleanup_inactive_cloud_resources.sh --project sales-engineering-sf --max-inactive-time-hours 48 --flexible-only
+          EXCLUDE="application-monitoring-aspnetcore,application-monitoring-flask,application-monitoring-laravel,application-monitoring-node,application-monitoring-rails,application-monitoring-react,application-monitoring-ruby,application-monitoring-vue,springboot"
+          bin/cleanup_inactive_cloud_resources.sh --project sales-engineering-sf --max-inactive-time-hours 336 --exclude-services "$EXCLUDE"
+          bin/cleanup_inactive_cloud_resources.sh --project sales-engineering-sf --max-inactive-time-hours 48 --flexible-only --exclude-services "$EXCLUDE"
         working-directory: ./empower
           
       - run: echo "Job status is ${{ job.status }}."

--- a/.github/workflows/cleanup_inactive_cloud_resources.yml
+++ b/.github/workflows/cleanup_inactive_cloud_resources.yml
@@ -3,7 +3,7 @@ run-name: Deployment triggered by ${{ github.event_name }} / ${{ github.actor }}
 
 on:
   schedule:
-    - cron:  '0 0 * * *' # every day at midnight UTC 
+    - cron:  '40 3 * * *' # every day at 8:40pm PDT / 5:40am GMT+2
     # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   workflow_dispatch:
 
@@ -21,6 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Report job start to Cron monitor (demo/cleanup_inactive_cloud_resources)
+        run: |
+          SENTRY_CRON='https://o87286.ingest.sentry.io/api/4505620224540672/cron/cleanup_inactive_cloud_resources/21b95d7975af21218dd7c14f1e48e193/'
+          curl "$SENTRY_CRON?status=in_progress"
+          echo "SENTRY_CRON=$SENTRY_CRON" >> "$GITHUB_ENV"
+
       - name: Check out this repository code
         uses: actions/checkout@v3
         with:
@@ -60,3 +66,11 @@ jobs:
         working-directory: ./empower
           
       - run: echo "Job status is ${{ job.status }}."
+
+      - name: Report success to Cron monitor (demo/cleanup_inactive_cloud_resources)
+        run: curl "${{ env.SENTRY_CRON }}?status=ok"
+    
+      # 'always' ensures step is run even if earlier step failed
+      - name: Report error to Cron monitor (demo/cleanup_inactive_cloud_resources)
+        if: always() && job.status == 'failure'
+        run: curl "${{ env.SENTRY_CRON }}?status=error"

--- a/bin/cleanup_inactive_cloud_resources.sh
+++ b/bin/cleanup_inactive_cloud_resources.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Function to print the script usage.
+function show_usage() {
+  echo "Usage: $0 --project <gcp_project_id> --max-inactive-time-hours <max_inactive_time_hours> [--flexible-only] [--dry-run] [--service-id-contains <substring>]"
+}
+
+# Default values for optional arguments.
+DRY_RUN=false
+FLEXIBLE_ONLY=false
+services_deleted=0
+
+# Parse the arguments using getopts.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      GCP_PROJECT_ID="$2"
+      shift 2
+      ;;
+    --max-inactive-time-hours)
+      MAX_INACTIVE_TIME_HOURS="$2"
+      shift 2
+      ;;
+    --flexible-only)
+      FLEXIBLE_ONLY=true
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      dryrun_suffix=" (dry run)"
+      shift
+      ;;
+    --service-id-contains)
+      SERVICE_ID_CONTAINS="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: Invalid option '$1'"
+      show_usage
+      exit 1
+      ;;
+  esac
+done
+
+# Check if the required arguments are provided.
+if [[ -z $GCP_PROJECT_ID || -z $MAX_INACTIVE_TIME_HOURS ]]; then
+  echo "Error: Missing required arguments."
+  show_usage
+  exit 1
+fi
+
+# Convert MAX_INACTIVE_TIME_HOURS to seconds.
+MAX_INACTIVE_TIME_SECONDS=$(( MAX_INACTIVE_TIME_HOURS * 3600 ))
+
+# Function to convert a timestamp to Unix timestamp (epoch time).
+function to_unix_timestamp() {
+  TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$1" "+%s"
+}
+
+# Function to truncate a string to fit within the given width.
+function truncate_string() {
+  local str="$1"
+  local width=$2
+  if [ "${#str}" -gt "$width" ]; then
+    echo "${str:0:$((width - 3))}..."
+  else
+    echo "$str"
+  fi
+}
+
+# Function to convert seconds to a human-readable format.
+function format_duration() {
+  local seconds=$1
+  if (( seconds >= 86400 )); then
+    echo "$(( seconds / 86400 )) days ago"
+  elif (( seconds >= 3600 )); then
+    echo "$(( seconds / 3600 )) hours ago"
+  elif (( seconds >= 60 )); then
+    echo "$(( seconds / 60 )) minutes ago"
+  else
+    echo "$seconds seconds ago"
+  fi
+}
+
+# Function to print the tabular output for the header.
+function print_table_header() {
+  printf "%-40s %-13s %-17s %-17s %-23s %-16s\n" "Service ID" "Environment" "Last Request" "Last Deploy" "Deployer" "Action Taken"
+}
+
+# Function to print the tabular output for a row.
+function print_table_row() {
+  local service_id=$1
+  local environment=$2
+  local last_request_rel=$3
+  local last_deploy_rel=$4
+  local last_deployer=$5
+  local action=$6
+  if [[ $last_request_rel == -1 ]]; then
+    last_request_rel_h="> "$(format_duration "$MAX_INACTIVE_TIME_SECONDS")
+  else
+    last_request_rel_h=$(format_duration "$last_request_rel")
+  fi
+  last_deploy_rel_h=$(format_duration "$last_deploy_rel")
+  # Truncate the service ID if it exceeds the width.
+  local truncated_service_id=$(truncate_string "$service_id" 40)
+  printf "%-40s %-13s %-17s %-17s %-23s %-16s\n" "$truncated_service_id" "$environment" "$last_request_rel_h" "$last_deploy_rel_h" "$last_deployer" "$action"
+}
+
+# Print the header for the table using the print_table_header function.
+print_table_header
+
+# Get a list of all services in the GCP project.
+services=$(gcloud app services list --project="${GCP_PROJECT_ID}" --format="value(id)")
+
+# Loop through each service and check its last request time and last deployer.
+for service in $services; do
+  # Check if the service ID contains the specified substring (if provided).
+  if [[ -n $SERVICE_ID_CONTAINS && ! $service =~ $SERVICE_ID_CONTAINS ]]; then
+    continue
+  fi
+
+  # Get the environment for the service using "gcloud app versions list".
+  environment=$(gcloud app versions list --service="${service}" --project="${GCP_PROJECT_ID}" --filter="traffic_split=1.0" --format="value(environment.name)" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+
+  if [ "$FLEXIBLE_ONLY" = true ] && [ "$environment" != "flex" ]; then
+    continue
+  fi
+
+  # Get the last request time for the service by querying the logs.
+  # For standard environment, use "appengine.googleapis.com%2Frequest_log" log name.
+  # For flexible environment, use "appengine.googleapis.com%2Fnginx.request" log name.
+  # First, check logs with freshness of 1 day.
+  last_request_time=$(gcloud logging read "resource.type=gae_app AND resource.labels.module_id=${service} AND logName=\"projects/${GCP_PROJECT_ID}/logs/appengine.googleapis.com%2Frequest_log\" OR logName=\"projects/${GCP_PROJECT_ID}/logs/appengine.googleapis.com%2Fnginx.request\" AND NOT protoPayload.userAgent =~ \"bot\"" --project="${GCP_PROJECT_ID}" --format="value(timestamp)" --limit=1 --freshness="1d" 2>/dev/null)
+
+  # If no results found for 1 day, query logs for the entire max inactivity period.
+  if [[ -z $last_request_time ]]; then
+    last_request_time=$(gcloud logging read "resource.type=gae_app AND resource.labels.module_id=${service} AND logName=\"projects/${GCP_PROJECT_ID}/logs/appengine.googleapis.com%2Frequest_log\" OR logName=\"projects/${GCP_PROJECT_ID}/logs/appengine.googleapis.com%2Fnginx.request\" AND NOT protoPayload.userAgent =~ \"bot\"" --project="${GCP_PROJECT_ID}" --format="value(timestamp)" --limit=1 --freshness="${MAX_INACTIVE_TIME_SECONDS}S" 2>/dev/null)
+  fi
+
+  # Calculate the duration of inactivity in seconds.
+  if [[ -z $last_request_time ]]; then
+    last_request_rel=-1
+  else
+    last_request_rel=$(( $(TZ=UTC date "+%s") - $(to_unix_timestamp "${last_request_time%.*}") ))
+  fi
+  
+  # Get the last deployment time for the service using "gcloud app versions list".
+  last_deploy_time=$(gcloud app versions list --service="${service}" --project="${GCP_PROJECT_ID}" --filter="traffic_split=1.0" --format="value(version.createTime)" 2>/dev/null)
+  last_deploy_rel=$(( $(TZ=UTC date "+%s") - $(to_unix_timestamp "${last_deploy_time%Z}") ))
+
+
+  # Get the last deployer for the service using "gcloud app versions list".
+  last_deployer=$(gcloud app versions list --service="${service}" --project="${GCP_PROJECT_ID}" --filter="traffic_split=1.0" --format="value(version.createdBy)" 2>/dev/null)
+
+  # Strip everything starting with "@" from the last deployer.
+  last_deployer="${last_deployer%%@*}"
+
+  # If the service has never received a request or is inactive for more than the specified time, take appropriate action.
+  if [[ ( $last_request_rel -eq -1 || $last_request_rel -gt $MAX_INACTIVE_TIME_SECONDS ) && $last_deploy_rel -gt $MAX_INACTIVE_TIME_SECONDS ]]; then
+    action="delete$dryrun_suffix"
+    ((services_deleted++))
+  else
+    action="none"
+  fi
+  # Print the table row for the service.
+  print_table_row "$service" "$environment" "$last_request_rel" "$last_deploy_rel" "$last_deployer" "$action"
+
+  if [[ $action == "delete" ]]; then
+      gcloud app services delete "$service" --project="${GCP_PROJECT_ID}" --quiet
+  fi
+done
+
+# Output the total number of services that were (or would've been) shut down in both environments.
+echo -e "\nTotal number of services deleted$dryrun_suffix: $services_deleted"


### PR DESCRIPTION
# Testing
yml will be battle-tested

```
bin/cloud_resource_auto_shutdown.sh --project sales-engineering-sf --max-inactive-time-hours 24 --dry-run --service-id-contains staging
Service ID                               Environment   Last Request      Last Deploy       Deployer                Action Taken
staging-app-monitoring-aspnetcore        flex          > 1 days ago      65 days ago       matt.johnson-pint       delete (dry run)
staging-application-monitoring-aspnet... flex          > 1 days ago      127 days ago      kosty.maleyev           delete (dry run)
staging-application-monitoring-flask     standard      2 hours ago       65 days ago       kosty.maleyev           none
staging-application-monitoring-laravel   standard      > 1 days ago      186 days ago      katie.jenkins           delete (dry run)
staging-application-monitoring-node      standard      > 1 days ago      5 minutes ago     kosty.maleyev           none
staging-application-monitoring-rails     standard      > 1 days ago      127 days ago      gene.wright             delete (dry run)
staging-application-monitoring-react     standard      2 hours ago       1 days ago        kosty.maleyev           none
staging-application-monitoring-rubyon... standard      > 1 days ago      191 days ago      neil                    delete (dry run)
staging-application-monitoring-vue       standard      > 1 days ago      421 days ago      wcapozzoli              delete (dry run)
staging-ruby                             flex          > 1 days ago      345 days ago      wcapozzoli              delete (dry run)
staging-springboot                       flex          > 1 days ago      127 days ago      kosty.maleyev           delete (dry run)

Total number of Standard services deleted (dry run): 4
Total number of Flexible services deleted (dry run): 4
```