### PR TITLE
[spring-boot] Enable capture of request body

### DIFF
--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -27,7 +27,7 @@ function Checkout(props) {
       email = scope._user.email
     });
 
-    const response = await fetch(props.backend + "/checkout", {
+    const response = await fetch(props.backend + "/checkout?v2=true", {
       method: "POST",
       headers: { se, customerType, email, "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/spring-boot/src/main/resources/application.properties.template
+++ b/spring-boot/src/main/resources/application.properties.template
@@ -14,3 +14,8 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.continue-on-error=true
 #Enforces database initialization
 spring.datasource.initialization-mode=always
+
+# Must be set for request body to be captured
+sentry.max-request-body-size=always
+sentry.send-default-pii=true
+


### PR DESCRIPTION
# Testing
https://testorg-az.sentry.io/issues/4371253720/events/693a352fd9054916808cd1d70c5adc08/

Adding `v2` to `/checkout` query string should not break other backends but we might want to keep an eye out. I only tested Flask and it ~~works~~ breaks just fine: [sample event](https://testorg-az.sentry.io/issues/4117859548/events/0cc4093130a54cac9b150702f809a80f/)