### PR TITLE
[react] upgrade SDK to 7.61.1; rollback all deps minor versions

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,24 +8,24 @@
       "name": "application-monitoring",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "^7.60.0",
-        "@testing-library/jest-dom": "^5.11.4",
-        "@testing-library/react": "^11.1.0",
-        "@testing-library/user-event": "^12.1.10",
-        "history": "^5.3.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "react-loader-spinner": "^4.0.0",
-        "react-redux": "^7.2.4",
-        "react-router-dom": "^6.3.0",
+        "@sentry/react": "~7.61.1",
+        "@testing-library/jest-dom": "~5.11.4",
+        "@testing-library/react": "~11.1.0",
+        "@testing-library/user-event": "~12.1.10",
+        "history": "~5.3.0",
+        "react": "~17.0.2",
+        "react-dom": "~17.0.2",
+        "react-loader-spinner": "~4.0.0",
+        "react-redux": "~7.2.4",
+        "react-router-dom": "~6.3.0",
         "react-scripts": "4.0.3",
-        "redux": "^4.1.0",
-        "redux-logger": "^3.0.6",
-        "web-vitals": "^1.0.1"
+        "redux": "~4.1.0",
+        "redux-logger": "~3.0.6",
+        "web-vitals": "~1.0.1"
       },
       "devDependencies": {
-        "@sentry/webpack-plugin": "^2.4.0",
-        "react-app-rewired": "^2.2.1"
+        "@sentry/webpack-plugin": "~2.4.0",
+        "react-app-rewired": "~2.2.1"
       },
       "engines": {
         "node": ">=16.0.0 <17.0.0",
@@ -1813,14 +1813,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5.tgz",
-      "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -1878,13 +1870,13 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.60.0.tgz",
-      "integrity": "sha512-2qvxmR954H+K7u4o92sS2u+hntzshem9XwfHAqDvBe51arNbFVy8LfJTJ5fffgZq/6jXlozCO0/6aR5yLR5mBg==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.61.1.tgz",
+      "integrity": "sha512-E8J6ZMXHGdWdmgKBK/ounuUppDK65c4Hphin6iVckDGMEATn0auYAKngeyRUMLof1167DssD8wxcIA4aBvmScA==",
       "dependencies": {
-        "@sentry/core": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/core": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -1892,12 +1884,12 @@
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.0.tgz",
-      "integrity": "sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.1.tgz",
+      "integrity": "sha512-WTRt0J33KhUbYuDQZ5G58kdsNeQ5JYrpi6o+Qz+1xTv60DQq/tBGRJ7d86SkmdnGIiTs6W1hsxAtyiLS0y9d2A==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -1905,19 +1897,19 @@
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-      "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+      "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-      "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+      "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
+        "@sentry/types": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -1925,15 +1917,15 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.60.0.tgz",
-      "integrity": "sha512-WznY6zrJxCUHZns8jTvDsZw3aaHriSP+jqD+wkXZG3ceooQwFn0RkAstUuoG7YyP4Foinznn3+caeQD4ZjWaXQ==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.61.1.tgz",
+      "integrity": "sha512-v6Wv0O/PF+sqji+WWpJmxAlQafsiKmsXQLzKAIntVjl3HbYO5oVS3ubCyqfxSlLxIhM5JuHcEOLn6Zi3DPtpcw==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.60.0",
-        "@sentry/core": "7.60.0",
-        "@sentry/replay": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry-internal/tracing": "7.61.1",
+        "@sentry/core": "7.61.1",
+        "@sentry/replay": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -1941,12 +1933,12 @@
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/core": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.0.tgz",
-      "integrity": "sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.1.tgz",
+      "integrity": "sha512-WTRt0J33KhUbYuDQZ5G58kdsNeQ5JYrpi6o+Qz+1xTv60DQq/tBGRJ7d86SkmdnGIiTs6W1hsxAtyiLS0y9d2A==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -1954,19 +1946,19 @@
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/types": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-      "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+      "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/utils": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-      "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+      "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
+        "@sentry/types": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -2242,13 +2234,13 @@
       "dev": true
     },
     "node_modules/@sentry/react": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.60.0.tgz",
-      "integrity": "sha512-wmtRc0jwcqY+AM9dbOBLUCOy2rwh7MvDIXHq49Sg6r/ywOKBV0C55RnU3w7MAcmYe6aylNHC8DChHoj+phIvZw==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.61.1.tgz",
+      "integrity": "sha512-n8xNT05gdERpETvq3GJZ2lP6HZYLRQQoUDc13egDzKf840MzCjle0LiLmsVhRv8AL1GnWaIPwnvTGvS4BuNlvw==",
       "dependencies": {
-        "@sentry/browser": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/browser": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^2.4.1 || ^1.9.3"
       },
@@ -2260,19 +2252,19 @@
       }
     },
     "node_modules/@sentry/react/node_modules/@sentry/types": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-      "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+      "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react/node_modules/@sentry/utils": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-      "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+      "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
+        "@sentry/types": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -2280,25 +2272,25 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.60.0.tgz",
-      "integrity": "sha512-iVSs+mhgjeK0qqLdCqbCa1P4I6hETHCUq14pTYp0bwGrI1D/a1Ho/6wLkwXv47Gnrwaba/7JFM+IxZcN4FzfmQ==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.61.1.tgz",
+      "integrity": "sha512-Nsnnzx8c+DRjnfQ0Md11KGdY21XOPa50T2B3eBEyFAhibvYEc/68PuyVWkMBQ7w9zo/JV+q6HpIXKD0THUtqZA==",
       "dependencies": {
-        "@sentry/core": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0"
+        "@sentry/core": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/replay/node_modules/@sentry/core": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.0.tgz",
-      "integrity": "sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.1.tgz",
+      "integrity": "sha512-WTRt0J33KhUbYuDQZ5G58kdsNeQ5JYrpi6o+Qz+1xTv60DQq/tBGRJ7d86SkmdnGIiTs6W1hsxAtyiLS0y9d2A==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -2306,19 +2298,19 @@
       }
     },
     "node_modules/@sentry/replay/node_modules/@sentry/types": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-      "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+      "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay/node_modules/@sentry/utils": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-      "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+      "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
       "dependencies": {
-        "@sentry/types": "7.60.0",
+        "@sentry/types": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -2719,12 +2711,12 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
-      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.1.2.tgz",
+      "integrity": "sha512-foL0/Mo68M51DdgFwEsO2SDEkUpocuEYidOTcJACGEcoakZDINuERYwVdd6T5e3pPE+BZyGwwURaXcrX1v9RbQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@babel/runtime": "^7.12.1",
+        "@testing-library/dom": "^7.26.6"
       },
       "engines": {
         "node": ">=10"
@@ -2743,11 +2735,11 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+      "version": "12.1.10",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.10.tgz",
+      "integrity": "sha512-StlNdKHp2Rpb7yrny/5/CGpz8bR3jLa1Ge59ODGU6TmAhkrxSpvR6tCD1gaMFkkjEUWkmmye8BaXsZPcaiJ6Ug==",
       "dependencies": {
-        "@babel/runtime": "^7.12.5"
+        "@babel/runtime": "^7.10.2"
       },
       "engines": {
         "node": ">=10",
@@ -14474,29 +14466,23 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.5.tgz",
-      "integrity": "sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
       "dependencies": {
-        "@remix-run/router": "1.0.5"
-      },
-      "engines": {
-        "node": ">=14"
+        "history": "^5.2.0"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.5.tgz",
-      "integrity": "sha512-a7HsgikBR0wNfroBHcZUCd9+mLRqZS8R5U1Z1mzLWxFXEkUT3vR1XXmSIVoVpxVX8Bar0nQYYYc9Yipq8dWwAA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
       "dependencies": {
-        "@remix-run/router": "1.0.5",
-        "react-router": "6.4.5"
-      },
-      "engines": {
-        "node": ">=14"
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -18198,9 +18184,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.1.tgz",
-      "integrity": "sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.0.1.tgz",
+      "integrity": "sha512-io/H/D18edTL1D2lcaUTLNLFEVZIPhNd4IdXDB9bEb+uDv2m/6NfyHiXKLFjbmI1ubeYpoQpR1gl9nlcWdI0vA=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -20614,11 +20600,6 @@
         }
       }
     },
-    "@remix-run/router": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5.tgz",
-      "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug=="
-    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -20663,76 +20644,76 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.60.0.tgz",
-      "integrity": "sha512-2qvxmR954H+K7u4o92sS2u+hntzshem9XwfHAqDvBe51arNbFVy8LfJTJ5fffgZq/6jXlozCO0/6aR5yLR5mBg==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.61.1.tgz",
+      "integrity": "sha512-E8J6ZMXHGdWdmgKBK/ounuUppDK65c4Hphin6iVckDGMEATn0auYAKngeyRUMLof1167DssD8wxcIA4aBvmScA==",
       "requires": {
-        "@sentry/core": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/core": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.0.tgz",
-          "integrity": "sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.1.tgz",
+          "integrity": "sha512-WTRt0J33KhUbYuDQZ5G58kdsNeQ5JYrpi6o+Qz+1xTv60DQq/tBGRJ7d86SkmdnGIiTs6W1hsxAtyiLS0y9d2A==",
           "requires": {
-            "@sentry/types": "7.60.0",
-            "@sentry/utils": "7.60.0",
+            "@sentry/types": "7.61.1",
+            "@sentry/utils": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-          "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA=="
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+          "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw=="
         },
         "@sentry/utils": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-          "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+          "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
           "requires": {
-            "@sentry/types": "7.60.0",
+            "@sentry/types": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
     },
     "@sentry/browser": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.60.0.tgz",
-      "integrity": "sha512-WznY6zrJxCUHZns8jTvDsZw3aaHriSP+jqD+wkXZG3ceooQwFn0RkAstUuoG7YyP4Foinznn3+caeQD4ZjWaXQ==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.61.1.tgz",
+      "integrity": "sha512-v6Wv0O/PF+sqji+WWpJmxAlQafsiKmsXQLzKAIntVjl3HbYO5oVS3ubCyqfxSlLxIhM5JuHcEOLn6Zi3DPtpcw==",
       "requires": {
-        "@sentry-internal/tracing": "7.60.0",
-        "@sentry/core": "7.60.0",
-        "@sentry/replay": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry-internal/tracing": "7.61.1",
+        "@sentry/core": "7.61.1",
+        "@sentry/replay": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.0.tgz",
-          "integrity": "sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.1.tgz",
+          "integrity": "sha512-WTRt0J33KhUbYuDQZ5G58kdsNeQ5JYrpi6o+Qz+1xTv60DQq/tBGRJ7d86SkmdnGIiTs6W1hsxAtyiLS0y9d2A==",
           "requires": {
-            "@sentry/types": "7.60.0",
-            "@sentry/utils": "7.60.0",
+            "@sentry/types": "7.61.1",
+            "@sentry/utils": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-          "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA=="
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+          "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw=="
         },
         "@sentry/utils": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-          "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+          "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
           "requires": {
-            "@sentry/types": "7.60.0",
+            "@sentry/types": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
@@ -20936,64 +20917,64 @@
       }
     },
     "@sentry/react": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.60.0.tgz",
-      "integrity": "sha512-wmtRc0jwcqY+AM9dbOBLUCOy2rwh7MvDIXHq49Sg6r/ywOKBV0C55RnU3w7MAcmYe6aylNHC8DChHoj+phIvZw==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.61.1.tgz",
+      "integrity": "sha512-n8xNT05gdERpETvq3GJZ2lP6HZYLRQQoUDc13egDzKf840MzCjle0LiLmsVhRv8AL1GnWaIPwnvTGvS4BuNlvw==",
       "requires": {
-        "@sentry/browser": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0",
+        "@sentry/browser": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-          "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA=="
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+          "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw=="
         },
         "@sentry/utils": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-          "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+          "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
           "requires": {
-            "@sentry/types": "7.60.0",
+            "@sentry/types": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
     },
     "@sentry/replay": {
-      "version": "7.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.60.0.tgz",
-      "integrity": "sha512-iVSs+mhgjeK0qqLdCqbCa1P4I6hETHCUq14pTYp0bwGrI1D/a1Ho/6wLkwXv47Gnrwaba/7JFM+IxZcN4FzfmQ==",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.61.1.tgz",
+      "integrity": "sha512-Nsnnzx8c+DRjnfQ0Md11KGdY21XOPa50T2B3eBEyFAhibvYEc/68PuyVWkMBQ7w9zo/JV+q6HpIXKD0THUtqZA==",
       "requires": {
-        "@sentry/core": "7.60.0",
-        "@sentry/types": "7.60.0",
-        "@sentry/utils": "7.60.0"
+        "@sentry/core": "7.61.1",
+        "@sentry/types": "7.61.1",
+        "@sentry/utils": "7.61.1"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.60.0.tgz",
-          "integrity": "sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.61.1.tgz",
+          "integrity": "sha512-WTRt0J33KhUbYuDQZ5G58kdsNeQ5JYrpi6o+Qz+1xTv60DQq/tBGRJ7d86SkmdnGIiTs6W1hsxAtyiLS0y9d2A==",
           "requires": {
-            "@sentry/types": "7.60.0",
-            "@sentry/utils": "7.60.0",
+            "@sentry/types": "7.61.1",
+            "@sentry/utils": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.60.0.tgz",
-          "integrity": "sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA=="
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.61.1.tgz",
+          "integrity": "sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw=="
         },
         "@sentry/utils": {
-          "version": "7.60.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.60.0.tgz",
-          "integrity": "sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==",
+          "version": "7.61.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.61.1.tgz",
+          "integrity": "sha512-pUPXoiuYrTEPcBHjRizFB6eZEGm/6cTBwdWSHUjkGKvt19zuZ1ixFJQV6LrIL/AMeiQbmfQ+kTd/8SR7E9rcTQ==",
           "requires": {
-            "@sentry/types": "7.60.0",
+            "@sentry/types": "7.61.1",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
@@ -21269,12 +21250,12 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
-      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.1.2.tgz",
+      "integrity": "sha512-foL0/Mo68M51DdgFwEsO2SDEkUpocuEYidOTcJACGEcoakZDINuERYwVdd6T5e3pPE+BZyGwwURaXcrX1v9RbQ==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@babel/runtime": "^7.12.1",
+        "@testing-library/dom": "^7.26.6"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -21288,11 +21269,11 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+      "version": "12.1.10",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.10.tgz",
+      "integrity": "sha512-StlNdKHp2Rpb7yrny/5/CGpz8bR3jLa1Ge59ODGU6TmAhkrxSpvR6tCD1gaMFkkjEUWkmmye8BaXsZPcaiJ6Ug==",
       "requires": {
-        "@babel/runtime": "^7.12.5"
+        "@babel/runtime": "^7.10.2"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -30514,20 +30495,20 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "react-router": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.5.tgz",
-      "integrity": "sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
       "requires": {
-        "@remix-run/router": "1.0.5"
+        "history": "^5.2.0"
       }
     },
     "react-router-dom": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.5.tgz",
-      "integrity": "sha512-a7HsgikBR0wNfroBHcZUCd9+mLRqZS8R5U1Z1mzLWxFXEkUT3vR1XXmSIVoVpxVX8Bar0nQYYYc9Yipq8dWwAA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
       "requires": {
-        "@remix-run/router": "1.0.5",
-        "react-router": "6.4.5"
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
       }
     },
     "react-scripts": {
@@ -33414,9 +33395,9 @@
       }
     },
     "web-vitals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.1.tgz",
-      "integrity": "sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.0.1.tgz",
+      "integrity": "sha512-io/H/D18edTL1D2lcaUTLNLFEVZIPhNd4IdXDB9bEb+uDv2m/6NfyHiXKLFjbmI1ubeYpoQpR1gl9nlcWdI0vA=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/react/package.json
+++ b/react/package.json
@@ -3,20 +3,20 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "^7.60.0",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
-    "history": "^5.3.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-loader-spinner": "^4.0.0",
-    "react-redux": "^7.2.4",
-    "react-router-dom": "^6.3.0",
+    "@sentry/react": "~7.61.1",
+    "@testing-library/jest-dom": "~5.11.4",
+    "@testing-library/react": "~11.1.0",
+    "@testing-library/user-event": "~12.1.10",
+    "history": "~5.3.0",
+    "react": "~17.0.2",
+    "react-dom": "~17.0.2",
+    "react-loader-spinner": "~4.0.0",
+    "react-redux": "~7.2.4",
+    "react-router-dom": "~6.3.0",
     "react-scripts": "4.0.3",
-    "redux": "^4.1.0",
-    "redux-logger": "^3.0.6",
-    "web-vitals": "^1.0.1"
+    "redux": "~4.1.0",
+    "redux-logger": "~3.0.6",
+    "web-vitals": "~1.0.1"
   },
   "scripts": {
     "start": "react-app-rewired start",
@@ -47,7 +47,7 @@
     ]
   },
   "devDependencies": {
-    "@sentry/webpack-plugin": "^2.4.0",
-    "react-app-rewired": "^2.2.1"
+    "@sentry/webpack-plugin": "~2.4.0",
+    "react-app-rewired": "~2.2.1"
   }
 }


### PR DESCRIPTION
* Upgrade SDK to 7.61.1 which has bugfix for child spans
* Change all dependencies minor versions to use ~ instead of ^ in package.json in case somebody in the future runs `npm install` instead of `npm ci` (preferred), rollback locked versions back to those in package.json (@JonasBa please lmk if any of those were intentional/required for your change)

# Testing
just basic: [example transaction](https://testorg-az.sentry.io/performance/staging-frontend-javascript:15bb9b650fbf4be5b661a29296fea7f9/?project=4504708328325120&query=transaction.op%3Apageload&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=5h&transaction=%2Fproducts&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)
