### PR TITLE
feat: fill form with default values for checkout

### DIFF
--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -9,15 +9,15 @@ function Checkout(props) {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [form, setForm] = useState({
-    email: '',
+    email: 'plant.lover@gardening.com',
     subscribe: '',
-    firstName: '',
-    lastName: '',
-    address: '',
-    city: '',
-    country: '',
-    state: '',
-    zipCode: '',
+    firstName: 'Jane',
+    lastName: 'Greenthumb',
+    address: '1199 9th Ave',
+    city: 'San Francisco',
+    country: 'United States of America',
+    state: 'CA',
+    zipCode: '94122',
   });
 
   async function checkout(cart) {
@@ -117,7 +117,6 @@ function Checkout(props) {
               type="email"
               onChange={handleInputChange}
               defaultValue={form.email}
-              placeholder="joebobson@joeb.com"
             />
 
             <input
@@ -141,7 +140,6 @@ function Checkout(props) {
               type="text"
               onChange={handleInputChange}
               defaultValue={form.firstName}
-              placeholder="Joe"
               className="half-width"
             />
             <label htmlFor="lastName" className="sentry-unmask">
@@ -153,7 +151,6 @@ function Checkout(props) {
               type="text"
               onChange={handleInputChange}
               defaultValue={form.lastName}
-              placeholder="Bobson"
             />
 
             <label htmlFor="address" className="sentry-unmask">
@@ -165,7 +162,6 @@ function Checkout(props) {
               type="text"
               onChange={handleInputChange}
               defaultValue={form.address}
-              placeholder="123 Main Street"
             />
 
             <label htmlFor="city" className="sentry-unmask">
@@ -177,7 +173,6 @@ function Checkout(props) {
               type="text"
               onChange={handleInputChange}
               defaultValue={form.city}
-              placeholder="Hope Springs"
             />
 
             <label htmlFor="country" className="sentry-unmask">
@@ -189,7 +184,6 @@ function Checkout(props) {
               type="text"
               onChange={handleInputChange}
               defaultValue={form.country}
-              placeholder="United States of America"
             />
 
             <label htmlFor="state" className="sentry-unmask">
@@ -201,7 +195,6 @@ function Checkout(props) {
               type="text"
               onChange={handleInputChange}
               defaultValue={form.state}
-              placeholder="Indiana"
             />
 
             <label htmlFor="zipCode" className="sentry-unmask">


### PR DESCRIPTION
- Automatically fill out form with values per https://github.com/sentry-demos/empower/issues/250
- Easter egg: the address is for SF botanical garden

## Screenshot
<img width="926" alt="Screenshot 2023-08-18 at 12 12 10 PM" src="https://github.com/sentry-demos/empower/assets/12092849/5460df0e-cfdb-4a26-b366-f77cebc789cc">
