### PR TITLE
test(sourcemaps): explicit empty value

### DIFF
--- a/react/config-overrides.js
+++ b/react/config-overrides.js
@@ -5,12 +5,9 @@ module.exports = function override(config, env) {
   config.plugins.push(
     SentryWebpackPlugin.sentryWebpackPlugin({
       authToken: process.env.SENTRY_AUTH_TOKEN,
-      include: '.',
       org: 'testorg-az',
       project: 'frontend-javascript',
-      ignoreFile: '.sentrycliignore',
-      ignore: ['webpack.config.js'],
-      configFile: 'sentry.properties',
+      ignore: [],
     })
   );
   return config;


### PR DESCRIPTION
```
/**
     * One or more paths to ignore during upload.
     * Overrides entries in ignoreFile file.
     *
     * Defaults to `['node_modules']` if neither `ignoreFile` nor `ignore` is set.
     */
    ignore?: string | string[];
```
I wonder if we somehow hit ^ case and we ended up always ignoring node_modules