### PR TITLE
react: perform all build-related parts in package.json:build

### DIFF
--- a/react/build.sh
+++ b/react/build.sh
@@ -7,9 +7,5 @@ set -e # exit immediately if any command exits with a non-zero status
 rm -rf build
 # npm ci does not update minor versions ->
 # (1) less chance of breaking (2) less noise in PR from package-lock.json
-npm ci 
-# below avoids source map processing error in Sentry when stacktrace includes inline JS
-export INLINE_RUNTIME_CHUNK=false
+npm ci
 npm run build # defined in 'scripts' in package.json
-
-cp ./serve.json build/serve.json

--- a/react/package.json
+++ b/react/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "INLINE_RUNTIME_CHUNK=false react-app-rewired build && cp serve.json build/",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -24,6 +24,12 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "scriptsComments": {
+    "build": [
+      "INLINE_RUNTIME_CHUNK is needed to avoid source map processing error in Sentry when stacktrace includes inline JS",
+      "serve.json is needed to set headers that enable browser profiling"
+    ]
+  },
   "engines": {
     "npm": ">=8.0.0 <9.0.0",
     "node": ">=16.0.0 <17.0.0"


### PR DESCRIPTION
this simplifies calling `npm run build` since it does all the necessary parts so I can use this effectively in a dockerfile