### PR TITLE
ruby: add an application server to allow running standalone

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 gem "sinatra"
 gem "sinatra-cors"
 
+# sinatra needs an app server
+gem 'webrick'
+
 gem "sentry-ruby"
 
 group :test do

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
       tilt (~> 2.0)
     sinatra-cors (1.2.0)
     tilt (2.0.10)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -46,6 +47,7 @@ DEPENDENCIES
   sentry-ruby
   sinatra
   sinatra-cors
+  webrick
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
webrick was picked because it does not depend on any native extensions -- meaning it is easier to install in a barebones docker image