### PR TITLE
[tda,ios] Bump iOS version to 15.5 to fix EXC_BAD_ACCESS in cli builds

### DIFF
--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -398,12 +398,12 @@ def ios_sim_driver(request, set_tags, selenium_endpoint):
         release_version = ReleaseVersion.latest_ios_github_release()
 
         options = XCUITestOptions().load_capabilities({
-            'appium:deviceName': 'iPhone 11 Simulator',
+            'appium:deviceName': 'iPhone 13 Simulator',
             'platformName': 'iOS',
-            'appium:platformVersion': '14.5',
+            'appium:platformVersion': '15.5',
 
             'sauce:options': {
-                'appiumVersion': '1.21.0',
+                'appiumVersion': '1.22.3',
                 'build': 'RDC-iOS-Mobile-Native',
                 'name': request.node.name,
             },


### PR DESCRIPTION
# Background
Some builds (not clear if those created in certain team member's laptops or those created using the new [make release](https://github.com/sentry-demos/ios/pull/47)target instead of XCode UI) have been crashing in SauceLabs simulator with EXC_BAD_ACCESS. We were able to reproduce that locally when building with XCode (not make) and using `iPhone 11 / iOS 14.5` (i.e. same version as in SauceLabs) as run destination in XCode, instead of default iOS 17 which ran fine. After finding the highest  (without needing to upgrade to Appium 2.x) platform version supported in SauceLabs - `iPhone 13 / iOS 15.5` I was able to successfully test that in the build doesn't crash on that iOS 15.5 simulator in XCode. I was additionally able to test that bumping the iOS version in SL using the existing latest release uploaded to GitHub results in successful tests and test events generated as expected (see below). The expectation is that deploying this will make the [new deploy script](https://github.com/sentry-demos/ios/pull/50) that automates release creation and upload finally usable.

# Testing
[sample error](https://demo.sentry.io/issues/4221692556/events/latest/?end=2023-10-03T03%3A59%3A52&project=6249899&query=+%21project%3Aempower-tda&referrer=latest-event&start=2023-10-03T03%3A56%3A20&stream_index=6)
[sample transaction](https://demo.sentry.io/performance/mobile-ios:d731555db67a43f5becb7df8dbfb0658/?project=6249899&query=&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=14d&transaction=EmpowerPlantViewController&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)