### PR TITLE
feat: Allow to pass `?repeat=X` to products/products-join pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ localhost:5000?crash=true
 
 Add +2 quantity of a single item to Cart and purchase in order to trigger an Error. Visit the routes defined in src/index.js to produce transactions.
 
+## Trigger slow performance
+
+You can pass `?repeat=X` to the `/products` and `/products-join` URLs, like this: `/products?repeat=100`. 
+This will render a higher number of list items, which shows slow performance in the frontend. 
+You can see a slow react render span in the resulting transaction.
+
 ## Deploy to Prod
 This script deploys the flagship apps React + Flask. For deploying a single app to App Engine, check each platform's README for specific instructions. Make sure you don't have any local changes to `env-config/production.env`.
 ```

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -64,12 +64,16 @@ class Products extends Component {
   async componentDidMount() {
     var products;
     try {
-      products = await this.getProducts();
       // take first 4 products because that's all we have img/title/description for
-      this.props.setProducts(Array(200/4).fill(products.slice(0, 4)).flat().map((p, n) => {
+      products = (await this.getProducts()).slice(0, 4);
+      const repeat = getRepeat() || 50;
+
+      const repeatedProducts = Array(repeat).fill(products).flat().map((p, n) => {
         p.id = n
         return p
-      }));
+      });
+
+      this.props.setProducts(repeatedProducts);
     } catch (err) {
       Sentry.captureException(new Error('app unable to load products: ' + err));
     }
@@ -130,3 +134,9 @@ const mapStateToProps = (state, ownProps) => {
 export default connect(mapStateToProps, { setProducts, addProduct })(
   Sentry.withProfiler(Products, { name: 'Products' })
 );
+
+function getRepeat() {
+  const url = new URL(window.location.href);
+  const repeat = parseInt(url.searchParams.get('repeat'));
+  return Number.isNaN(repeat) ? undefined : repeat;
+}

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -47,7 +47,14 @@ class ProductsJoin extends Component {
     var products;
     try {
       products = await this.getProductsJoin();
-      this.props.setProducts(products);
+      const repeat = getRepeat() || 1;
+
+      const repeatedProducts = Array(repeat).fill(products).flat().map((p, n) => {
+        p.id = n
+        return p
+      });
+
+      this.props.setProducts(repeatedProducts);
     } catch (err) {
       Sentry.captureException(new Error('app unable to load products'));
     }
@@ -108,3 +115,9 @@ const mapStateToProps = (state, ownProps) => {
 export default connect(mapStateToProps, { setProducts, addProduct })(
   Sentry.withProfiler(ProductsJoin, { name: 'ProductsJoin' })
 );
+
+function getRepeat() {
+  const url = new URL(window.location.href);
+  const repeat = parseInt(url.searchParams.get('repeat'));
+  return Number.isNaN(repeat) ? undefined : repeat;
+}


### PR DESCRIPTION
With this, you can pass `?repeat=X` to either the `/products` or `/products-join` pages.
This can be used to trigger a slow JS rendering to show frontend performance problems.

Example with 50 repeats: https://sentry-sdks.sentry.io/discover/francescos-test-js-project:ad14e92cf47740298021eda1c0b75346/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4505997288865792&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29

Example in combination with slow API query: https://sentry-sdks.sentry.io/discover/francescos-test-js-project:d9f34885c0ba41278c61cc541f0019c3/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4505997288865792&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29

Closes https://github.com/sentry-demos/empower/issues/273