### PR TITLE
upgrade flask to 3.x

### DIFF
--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.27.1
-blinker==1.4
-flask==2.0.3
+blinker==1.6.2
+flask==3.0.0
 flask-cors==3.0.10
 gunicorn==20.1.0
 numpy==1.23.2


### PR DESCRIPTION
failing on:

```
Traceback (most recent call last):
  File "/usr/local/bin/flask", line 5, in <module>
    from flask.cli import main
  File "/usr/local/lib/python3.11/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 28, in <module>
    from . import cli
  File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 18, in <module>
    from .helpers import get_debug_flag
  File "/usr/local/lib/python3.11/site-packages/flask/helpers.py", line 16, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.11/site-packages/werkzeug/urls.py)
```