### PR TITLE
prettier test names when parametrizing browsers

### DIFF
--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -109,6 +109,10 @@ desktop_browsers = [
         "browserName": "chrome",
         "browserVersion": "latest",
     }]
+desktop_browsers_ids = [
+    '{browserName}@{browserVersion}({platformName})'.format(**browser)
+    for browser in desktop_browsers
+]
 
 def pytest_addoption(parser):
     parser.addoption("--dc", action="store", default='us', help="Set Sauce Labs Data Center (US or EU)")
@@ -231,7 +235,7 @@ def set_tags(request):
     sentry_sdk.set_tag("pytestPlatform", platform)
     sentry_sdk.set_tag("pytestName", test_name)
 
-@pytest.fixture(params=desktop_browsers)
+@pytest.fixture(params=desktop_browsers, ids=desktop_browsers_ids)
 def desktop_web_driver(request, set_tags, selenium_endpoint):
 
     try:


### PR DESCRIPTION
before:

```
<Module tda/desktop_web/test_about_employees.py>
  <Function test_about_employees[desktop_web_driver0]>
  <Function test_about_employees[desktop_web_driver1]>
  <Function test_about_employees[desktop_web_driver2]>
  <Function test_about_employees[desktop_web_driver3]>
```

after:

```
<Module tda/desktop_web/test_about_employees.py>
  <Function test_about_employees[chrome@latest(Windows 10)]>
  <Function test_about_employees[firefox@latest(Windows 10)]>
  <Function test_about_employees[safari@latest-1(OS X 10.13)]>
  <Function test_about_employees[chrome@latest(OS X 10.13)]>
```