### PR TITLE
upgrade pyyaml to 6.0.1

### DIFF
--- a/tda/requirements.txt
+++ b/tda/requirements.txt
@@ -4,6 +4,6 @@ pytest-forked==1.4.0
 urllib3==1.26.14
 selenium==4.8.0
 Appium-Python-Client==2.8.1
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.28.2
 sentry-sdk==1.14.0


### PR DESCRIPTION
6.0 is incompatible with python 3.12