### PR TITLE
upgrade sentry-sdk to silence warnings

### DIFF
--- a/tda/requirements.txt
+++ b/tda/requirements.txt
@@ -6,4 +6,4 @@ selenium==4.8.0
 Appium-Python-Client==2.8.1
 PyYAML==6.0
 requests==2.28.2
-sentry-sdk==1.14.0
+sentry-sdk==1.32.0


### PR DESCRIPTION
most of these warnings are due to sentry-sdk using `pkg_resources` or `datetime.utcnow(...)`