### PR TITLE
upgrade pytest to 7.4.2

### DIFF
--- a/tda/requirements.txt
+++ b/tda/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.2.1
+pytest==7.4.2
 pytest-xdist==3.1.0
 pytest-forked==1.4.0
 urllib3==1.26.14


### PR DESCRIPTION
this fixes rewrite warnings in 3.12