### PR TITLE
[tda] fix deploy_tda.sh Text file busy: '..-tda/env/bin/python3.8'

### DIFF
--- a/tda/build.sh
+++ b/tda/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+deploy_id=$1
+
 set -e 
-virtualenv --python=`which python3.8` env
-source env/bin/activate 
+virtualenv --python=`which python3.8` "env$deploy_id"
+source "env$deploy_id/bin/activate"
 pip install -r requirements.txt

--- a/tda/deploy_tda.sh
+++ b/tda/deploy_tda.sh
@@ -38,8 +38,10 @@ echo "Code copied."
 
 if [[ $reqs_changed == "1" || $env_nonempty == "0" ]]; then
   echo "re-installing requirements (because requirements.txt changed OR 'env' directory does not exist or is empty)..."
+  deploy_id=$(openssl rand -hex 3 | tr -d '\n')
+
   # Host must have python3.8 and virtualenv installed
-  ssh $HOST 'cd '$DIR' && ./build.sh'
+  ssh $HOST 'cd '$DIR' && ./build.sh '$deploy_id
   if [ $? != 0 ]; then
     echo "[ERROR] failed to install requirements on destination host"
     exit 1
@@ -56,7 +58,7 @@ echo Killing any currently running TDA processes...
 ssh $HOST 'cd '$DIR' && ./stop.sh'
 
 echo "Starting TDA..."
-ssh $HOST 'cd '$DIR' && ./run.sh'
+ssh $HOST 'cd '$DIR' && ./run.sh '$deploy_id
 if [ $? != 0 ]; then
   echo "[ERROR] failed to start TDA"
   exit 1

--- a/tda/run.sh
+++ b/tda/run.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+deploy_id=$1
+
 # Validation
 if [ $(ls jobs/*.sh | wc -l) == 0 ]; then
   echo "[ERROR] No jobs found in jobs/ directory. Exiting."
@@ -11,9 +13,32 @@ if [ $(ls jobs/*.sh | wc -l) == 0 ]; then
 fi
 
 # Set up environment:
-# fetch and set release version upfront to reduce unnecessary API calls and avoid Github API rate limiting
-source env/bin/activate
+
+if [ ! -z $deploy_id ]; then
+  env_dir="env${deploy_id}"
+
+  if [ -d "$env_dir" ]; then
+    # If the directory exists, run the activate script within it
+    source "${env_dir}/bin/activate"
+  else
+    echo "Directory '$env_dir' does not exist."
+  fi
+else
+  # No argument provided, find the most recently created directory matching "env*"
+  env_dir="$(ls -td env* 2>/dev/null | head -n 1)"
+
+  if [ -n "$env_dir" ]; then
+    # If a directory is found, run the activate script within it
+    source "${env_dir}/bin/activate"
+  else
+    echo "[ERROR] No 'env*' directories found. Exiting."
+    exit 1
+  fi
+fi
+
 source .sauce_credentials
+
+# fetch and set release version upfront to reduce unnecessary API calls and avoid Github API rate limiting
 export LATEST_REACT_NATIVE_GITHUB_RELEASE=$(python3 latest_github_release.py react_native)
 export LATEST_ANDROID_GITHUB_RELEASE=$(python3 latest_github_release.py android)
 
@@ -29,3 +54,5 @@ for job in jobs/*.sh; do
   echo "Starting $job to run continuously in background..."
   nohup ./loop.sh ./$job >/dev/null 2>&1 &
 done
+
+find . -maxdepth 1 -type d -name "env*" ! -name "$env_dir" -exec rm -rf {} \; -exec echo "Deleted old virtualenv directory: {}" \;


### PR DESCRIPTION
Started getting this error out of the blue. Not sure what changed... previously we successfully set up a virtual environment "over" existing one and it didn't complain that `python3.8` binary in it was in use. @asottile-sentry maybe you know.
Maybe there was a simpler fix but I couldn't think of any.

```
./deploy_tda.sh
Checking ssh connection can be established...
Checking state of current deployment...
Files requirements.txt and /dev/fd/63 differ
Copying code to remote directory...
Code copied.
re-installing requirements (because requirements.txt changed OR 'env' directory does not exist or is empty)...
Using base prefix '/usr'
New python executable in /home/kosty_maleyev/empower_tda/env/bin/python3.8
/usr/lib/python3/dist-packages/virtualenv.py:1086: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 2375, in <module>
    main()
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 714, in main
    create_environment(home_dir,
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 944, in create_environment
    py_executable = os.path.abspath(install_python(
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 1278, in install_python
    shutil.copyfile(executable, py_executable)
  File "/usr/lib/python3.8/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
OSError: [Errno 26] Text file busy: '/home/kosty_maleyev/empower_tda/env/bin/python3.8'
Running virtualenv with interpreter /usr/bin/python3.8
[ERROR] failed to install requirements on destination host
```

# Testing
runs successfully, checked events coming into demo.sentry.io