### PR TITLE
[tda] security: remove option for saucelabs over http

### DIFF
--- a/tda/README.md
+++ b/tda/README.md
@@ -86,25 +86,6 @@ pip install -r requirements.txt
 ```
 6. Instead of using `py.test` or `pytest` executable that is probably global and points to your Python 3.10+ installation, use `python3 -m pytest` that will pick up the Python 3.8 from virtual environment. (Not an issue on GCP tda box)
 
-### SSL Cert Issues
-
-Problem: When locally running TDA tests, i.e. `py.test -s -n 4 desktop_web`, if you experience this error (or similar relating to SSL Cert):
-
-```
-E           urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='ondemand.us-west-1.saucelabs.com', port=443): Max retries exceeded with url: /wd/hub/session (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1091)')))
-
-venv/lib/python3.7/site-packages/urllib3/util/retry.py:574: MaxRetryError
-```
-
-<details>
-<summary>Click to toggle error screenshot</summary>
-
-![Screen Shot 2021-11-29 at 2 57 11 PM](https://user-images.githubusercontent.com/12092849/145083651-5479f05c-107f-4d46-a981-1c728679172f.png)
-
-</details>
-
-**Solution:** A workaround is to locally change the `SAUCELABS_PROTOCOL` constant in `conftest.py` from `https` to `http`.
-
 Note that handled errors will not increment the crash counts in Release Health. But the Release Health UI does separate Handled from Unhandled Issues.
 
 https://appium.io/docs/en/commands/device/app/launch-app/

--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -40,7 +40,6 @@ def get_current_time_iso_utc(adjust_seconds=0):
 
 start_time = get_current_time_iso_utc()
 
-SAUCELABS_PROTOCOL = "https://"
 DSN = "https://9802de20229e4afdaa0d60796cbb44d7@o87286.ingest.sentry.io/5390094"
 ENVIRONMENT = os.getenv("ENVIRONMENT") or "production"
 # SE_TAG will be both:
@@ -218,9 +217,9 @@ def selenium_endpoint(data_center):
     access_key = environ['SAUCE_ACCESS_KEY']
 
     if data_center and data_center.lower() == 'eu':
-        return SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
+        return "https://{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
     else:
-        return SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
+        return "https://{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
 
 @pytest.fixture
 def set_tags(request):


### PR DESCRIPTION
we should rotate the sauce credentials if someone has sent our creds in plaintext over http