### PR TITLE
Implement Frontend-Only Slow Performance Story

### DIFF
--- a/react/src/components/Home.js
+++ b/react/src/components/Home.js
@@ -40,7 +40,11 @@ class Home extends Component {
         <div className="hero-content">
           <h1>Empower your plants</h1>
           <p>Keep your houseplants happy.</p>
-          <Button to="/products">Browse products</Button>
+          <Button
+            to={this.props.frontendSlowdown ? '/products-fes' : '/products'}
+          >
+            Browse products
+          </Button>
         </div>
       </div>
     );

--- a/react/src/components/Nav.js
+++ b/react/src/components/Nav.js
@@ -61,7 +61,10 @@ class Nav extends Component {
               <Link to="/about" className="sentry-unmask">
                 About
               </Link>
-              <Link to="/products" className="sentry-unmask">
+              <Link
+                to={this.props.frontendSlowdown ? '/products-fes' : '/products'}
+                className="sentry-unmask"
+              >
                 Products
               </Link>
               <Link to="/cart">

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -74,6 +74,33 @@ class Products extends Component {
       Sentry.withScope(function (scope) {
         frontendSlowdown = scope._tags.frontendSlowdown;
       });
+
+      // Trigger a Sentry 'Performance Issue' in the case of
+      // a frontend slowdown
+      if (frontendSlowdown) {
+        // Must bust cache to have force transfer size
+        // small compressed file
+        let uc_small_script = document.createElement('script');
+        uc_small_script.async = false;
+        uc_small_script.src =
+          this.props.backend +
+          '/compressed_assets/compressed_small_file.js' +
+          '?cacheBuster=' +
+          Math.random();
+        document.body.appendChild(uc_small_script);
+
+        // big uncompressed file
+        let c_big_script = document.createElement('script');
+        c_big_script.async = false;
+
+        c_big_script.src =
+          this.props.backend +
+          '/uncompressed_assets/uncompressed_big_file.js' +
+          '?cacheBuster=' +
+          Math.random();
+        document.body.appendChild(c_big_script);
+      }
+
       products = await this.getProducts(frontendSlowdown);
       // If triggering a frontend-only slowdown, cause a render problem
       if (frontendSlowdown) {

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -70,14 +70,11 @@ class Products extends Component {
   async componentDidMount() {
     var products;
     try {
-      let frontendSlowdown;
-      Sentry.withScope(function (scope) {
-        frontendSlowdown = scope._tags.frontendSlowdown;
-      });
+      products = await this.getProducts(this.props.frontendSlowdown);
 
       // Trigger a Sentry 'Performance Issue' in the case of
       // a frontend slowdown
-      if (frontendSlowdown) {
+      if (this.props.frontendSlowdown) {
         // Must bust cache to have force transfer size
         // small compressed file
         let uc_small_script = document.createElement('script');
@@ -99,11 +96,8 @@ class Products extends Component {
           '?cacheBuster=' +
           Math.random();
         document.body.appendChild(c_big_script);
-      }
 
-      products = await this.getProducts(frontendSlowdown);
-      // If triggering a frontend-only slowdown, cause a render problem
-      if (frontendSlowdown) {
+        // When triggering a frontend-only slowdown, cause a slow render problem
         this.props.setProducts(
           Array(200 / 4)
             .fill(products.slice(0, 4))

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -60,6 +60,7 @@ if (window.location.hostname === 'localhost') {
 }
 
 let BACKEND_URL;
+let FRONTEND_SLOWDOWN;
 const DSN = process.env.REACT_APP_DSN;
 const RELEASE = process.env.REACT_APP_RELEASE;
 
@@ -193,6 +194,7 @@ class App extends Component {
 
       if (queryParams.get('frontendSlowdown') === 'true') {
         console.log('> frontend-only slowdown: true');
+        FRONTEND_SLOWDOWN = true;
         scope.setTag('frontendSlowdown', true);
       } else {
         console.log('> frontend + backend slowdown');
@@ -257,10 +259,18 @@ class App extends Component {
       <Provider store={store}>
         <BrowserRouter history={history}>
           <ScrollToTop />
-          <Nav />
+          <Nav frontendSlowdown={FRONTEND_SLOWDOWN} />
           <div id="body-container">
             <SentryRoutes>
-              <Route path="/" element={<Home backend={BACKEND_URL} />}></Route>
+              <Route
+                path="/"
+                element={
+                  <Home
+                    backend={BACKEND_URL}
+                    frontendSlowdown={FRONTEND_SLOWDOWN}
+                  />
+                }
+              ></Route>
               <Route
                 path="/about"
                 element={<About backend={BACKEND_URL} history={history} />}
@@ -281,6 +291,12 @@ class App extends Component {
               <Route
                 path="/products"
                 element={<Products backend={BACKEND_URL} />}
+              ></Route>
+              <Route
+                path="/products-fes" // fes = frontend slowdown (only frontend)
+                element={
+                  <Products backend={BACKEND_URL} frontendSlowdown={true} />
+                }
               ></Route>
               <Route
                 path="/nplusone"

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -166,9 +166,7 @@ class App extends Component {
     let queryParams = new URLSearchParams(history.location.search);
 
     // Set desired backend
-    let backendTypeParam = new URLSearchParams(history.location.search).get(
-      'backend'
-    );
+    let backendTypeParam = queryParams.get('backend');
     const backendType = determineBackendType(backendTypeParam);
     BACKEND_URL = determineBackendUrl(backendType, ENVIRONMENT);
 
@@ -190,9 +188,16 @@ class App extends Component {
         scope.setTag('se', queryParams.get('se'));
         // for use in Checkout.js when deciding whether to pre-fill form
         // lasts for as long as the tab is open
-        sessionStorage.setItem('se', queryParams.get('se'));  
+        sessionStorage.setItem('se', queryParams.get('se'));
       }
 
+      if (queryParams.get('frontendSlowdown') === 'true') {
+        console.log('> frontend-only slowdown: true');
+        scope.setTag('frontendSlowdown', true);
+      } else {
+        console.log('> frontend + backend slowdown');
+        scope.setTag('frontendSlowdown', false);
+      }
       if (queryParams.get('userFeedback')) {
         sessionStorage.setItem('userFeedback', queryParams.get('userFeedback'));
       } else {
@@ -207,7 +212,34 @@ class App extends Component {
         email = queryParams.get('userEmail');
       } else {
         // making fewer emails so event and user counts for an Issue are not the same
-        let array=['a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',];
+        let array = [
+          'a',
+          'b',
+          'c',
+          'd',
+          'e',
+          'f',
+          'g',
+          'h',
+          'i',
+          'j',
+          'k',
+          'l',
+          'm',
+          'n',
+          'o',
+          'p',
+          'q',
+          'r',
+          's',
+          't',
+          'u',
+          'v',
+          'w',
+          'x',
+          'y',
+          'z',
+        ];
         let a = array[Math.floor(Math.random() * array.length)];
         let b = array[Math.floor(Math.random() * array.length)];
         let c = array[Math.floor(Math.random() * array.length)];

--- a/tda/desktop_web/test_frontend_slowdown.py
+++ b/tda/desktop_web/test_frontend_slowdown.py
@@ -1,0 +1,24 @@
+import time
+import sentry_sdk
+from urllib.parse import urlencode
+
+def test_frontend_slowdown(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
+
+    for endpoint in endpoints.react_endpoints:
+        endpoint_products_join = endpoint + "/products-fes"
+        sentry_sdk.set_tag("endpoint", endpoint_products_join)
+
+        for i in range(batch_size):
+            # Ensures a different backend endpoint gets picked each time
+            url = ""
+            # TODO make a query_string builder function for sharing this across tests
+            query_string = {
+                # 'ruby' /products /checkout endpoints not available yet
+                'backend': backend(exclude=['ruby', 'laravel', 'aspnetcore'])
+            }
+            url = endpoint_products_join + '?' + urlencode(query_string)
+
+            desktop_web_driver.get(url)
+            time.sleep(sleep_length() + sleep_length() + 1)
+
+        # Checkout button not clicked yet in frontend slowdown flow

--- a/tda/desktop_web/test_frontend_slowdown.py
+++ b/tda/desktop_web/test_frontend_slowdown.py
@@ -5,8 +5,8 @@ from urllib.parse import urlencode
 def test_frontend_slowdown(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
 
     for endpoint in endpoints.react_endpoints:
-        endpoint_products_join = endpoint + "/products-fes"
-        sentry_sdk.set_tag("endpoint", endpoint_products_join)
+        endpoint_frontend_slowdown = endpoint + "/products-fes"
+        sentry_sdk.set_tag("endpoint", endpoint_frontend_slowdown)
 
         for i in range(batch_size):
             # Ensures a different backend endpoint gets picked each time
@@ -16,7 +16,7 @@ def test_frontend_slowdown(desktop_web_driver, endpoints, random, batch_size, ba
                 # 'ruby' /products /checkout endpoints not available yet
                 'backend': backend(exclude=['ruby', 'laravel', 'aspnetcore'])
             }
-            url = endpoint_products_join + '?' + urlencode(query_string)
+            url = endpoint_frontend_slowdown + '?' + urlencode(query_string)
 
             desktop_web_driver.get(url)
             time.sleep(sleep_length() + sleep_length() + 1)


### PR DESCRIPTION
Pass `frontendSlowdown=true` to trigger a frontend-only slowdown on a new `/products-fes` (fes = frontend slowdown) page.

- [x] triggers a quick backend products fetch when `frontendSlowdown=true` is passed, so as to make the http span smaller, and the frontend-only slow span stand out more clearly. See: https://github.com/sentry-demos/empower/issues/305
- [x] causes slow render problem when `frontendSlowdown=true` is passed, which creates the frontend-only slow span. See: https://github.com/sentry-demos/empower/issues/273
- [x] triggers a performance issue (this should happen, all the criteria are met for uncompressed asset performance issue; however, it can only be tested at scale so we plan to merge this in)

### Examples tested in staging
- [Frontend-only slowdown - Pageload transaction](https://demo.sentry.io/discover/staging-react:0ed952bed76b4d489947018cdeff594d/?field=title&field=transaction.duration&field=transaction.op&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4504708328325120&query=title%3A%2Fproducts-fes&sort=-transaction.duration&statsPeriod=7d&yAxis=count%28%29)
- [Frontend-only slowdown - Navigation transaction](https://demo.sentry.io/discover/staging-react:901958b3359242f1ba1d914af4048285/?field=title&field=transaction.duration&field=transaction.op&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4504708328325120&query=title%3A%2Fproducts-fes&sort=-transaction.duration&statsPeriod=7d&yAxis=count%28%29)
- [Frontend + Backend slowdown - Pageload transaction - functionality remains the same](https://demo.sentry.io/discover/staging-react:3f602f5d341b43eea2bccea029d9fe11/?field=title&field=transaction.duration&field=transaction.op&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4504708328325120&query=title%3A%2Fproducts&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29)

# Screenshots of Staging

<img width="1789" alt="Screenshot 2023-11-07 at 12 42 48 PM" src="https://github.com/sentry-demos/empower/assets/12092849/f8fc24fb-3d2e-485a-b32d-3a3165b3e1b6">

<img width="1782" alt="Screenshot 2023-11-07 at 12 41 50 PM" src="https://github.com/sentry-demos/empower/assets/12092849/e2256f96-637c-4d58-8db0-f0ad23645b5c">

## Navigation Transaction for `/products-fes`

<img width="1782" alt="Screenshot 2023-11-07 at 3 40 13 PM" src="https://github.com/sentry-demos/empower/assets/12092849/c1cf4ebb-8dec-4d36-a22f-42c03c8bb289">

## Pageload Transaction for `/products-fes`

Same as navigation transaction but with browser assets loading and stuff.

<img width="1786" alt="Screenshot 2023-11-07 at 4 00 59 PM" src="https://github.com/sentry-demos/empower/assets/12092849/dd01cb09-58b9-4782-abf1-4ed2b78409d5">

##  Continuing The Frontend-Only Slowdown Story

<img width="1790" alt="Screenshot 2023-11-07 at 3 47 42 PM" src="https://github.com/sentry-demos/empower/assets/12092849/3dfa43b5-34d3-4ed1-a992-f3f39cfb2590">

<img width="1783" alt="Screenshot 2023-11-07 at 3 49 13 PM" src="https://github.com/sentry-demos/empower/assets/12092849/2ac66dd7-fb4c-459a-ac7f-035360450c63">

