### PR TITLE
[crons-python] Attempt to fix deploy breaking in CI

### DIFF
--- a/auto-deploy.exclude
+++ b/auto-deploy.exclude
@@ -5,4 +5,3 @@ ruby
 laravel
 tda
 postgres
-crons-python

--- a/crons-python/deploy_project.sh
+++ b/crons-python/deploy_project.sh
@@ -10,6 +10,14 @@ source .env
 HOST="$CRONSPYTHON_DEPLOY_HOST"
 DIR="$CRONSPYTHON_DEPLOY_DIR"
 CRONTAB_USER=$CRONSPYTHON_CRONTAB_USER
+function ssh_cmd() {
+    local host_full=$1
+    local host_name=${host_full%%.*}
+    local rest=${host_full#*.}
+    local region=${rest%%.*}
+    shift
+    gcloud compute ssh $host_name --zone $region -- "$@" 2>&1 | grep -v '^Connection to .* closed\.' || true
+}
 
 function cleanup {
   echo "NOTE: if ssh check hangs, re-run 'gcloud compute config-ssh; ssh $HOST exit' to fix"
@@ -17,12 +25,12 @@ function cleanup {
 trap cleanup EXIT
 
 echo "Checking ssh connection can be established..."
-ssh $HOST exit
+ssh_cmd $HOST exit
 if [ $? != "0" ]; then
   echo "Running 'glcoud compute config-ssh' ..." 
   gcloud compute config-ssh
 fi
-ssh $HOST exit
+ssh_cmd $HOST exit
 if [ $? != "0" ]; then
   echo "[ERROR] Can't ssh into destination host. Please make sure your gcloud is set up correctly and you \
 have the right IAM permissions in sales-engingeering-sf GCP project."
@@ -34,11 +42,11 @@ trap - EXIT
 reqs_changed=0
 env_nonempty=0
 echo "Checking state of current deployment..."
-diff -q requirements.txt <(ssh $HOST 'cat '$DIR'/requirements.txt')
+diff -q requirements.txt <(ssh_cmd $HOST 'cat '$DIR'/requirements.txt')
 if [ $? == 1 ]; then # files differ or failed to compare
   reqs_changed=1
 fi
-if ssh $HOST '[[ -d '"$DIR/env"' ]] && [[ ! -z `ls -A '"$DIR/env"'` ]]'; then
+if ssh_cmd $HOST '[[ -d '"$DIR/env"' ]] && [[ ! -z `ls -A '"$DIR/env"'` ]]'; then
   env_nonempty=1
 fi
 
@@ -53,7 +61,7 @@ echo "Code copied."
 if [[ $reqs_changed == "1" || $env_nonempty == "0" ]]; then
   echo "re-installing requirements (because requirements.txt changed OR 'env' directory does not exist or is empty)..."
   # Host must have python3.8 and virtualenv installed
-  ssh $HOST 'cd '$DIR' && ./build.sh'
+  ssh_cmd $HOST 'cd '$DIR' && ./build.sh'
   if [ $? != 0 ]; then
     echo "[ERROR] failed to install requirements on destination host"
     exit 1
@@ -64,18 +72,18 @@ fi
 
 # handle case when crontab is empty
 echo "EXISTING crontab:"
-ssh $HOST 'sudo crontab -u '$CRONTAB_USER' -l'
+ssh_cmd $HOST 'sudo crontab -u '$CRONTAB_USER' -l'
 if [ $? != 0 ]; then
-  ssh $HOST 'echo "" | crontab -'
+  ssh_cmd $HOST 'echo "" | crontab -'
 fi
 echo "---"
 
 # set up cron job if not set up already
 # NOTE: this will overwrite any existing cron jobs from same project directory
-ssh $HOST '(sudo crontab -u '$CRONTAB_USER' -l | grep -v '"$DIR"'; cat '$DIR'/crontab) | sort - | uniq - | sudo crontab -u '$CRONTAB_USER' -'
+ssh_cmd $HOST '(sudo crontab -u '$CRONTAB_USER' -l | grep -v '"$DIR"'; cat '$DIR'/crontab) | sort - | uniq - | sudo crontab -u '$CRONTAB_USER' -'
 
 echo "UPDATED crontab:"
-ssh $HOST 'sudo crontab -u '$CRONTAB_USER' -l'
+ssh_cmd $HOST 'sudo crontab -u '$CRONTAB_USER' -l'
 echo "---"
 
 echo "Done. New code should be picked up when cron job runs next time."


### PR DESCRIPTION
directly using `ssh` command doesn't seem to work in GHA, even after running `gcloud ssh-config`.
Instead of trying to figure out paths to known_hosts and key files, figured it would be simpler to just use `gcloud compute ssh`

# Testing
local - OK
```
./deploy.sh --env=production crons-python
```

GHA:
tested that can connect with this approach
https://github.com/sentry-demos/empower/actions/runs/6885367036/job/18729396910