### PR TITLE
[vue] disable Vue in TDA

### DIFF
--- a/tda/jobs/desktop_web.sh
+++ b/tda/jobs/desktop_web.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-SE_TAG=tda BATCH_SIZE=random_20 pytest -s -n 7 desktop_web
+SE_TAG=tda BATCH_SIZE=random_20 pytest -s -n 7 --ignore-glob='*_vue.py' desktop_web


### PR DESCRIPTION
Discussed disabling Vue in TDA with Neil and Prithvi until we have resources or help to fix it and agreed to move forward with it.
- missing sourcemaps
- no session replay
- se tag is not propagating
- no automated deployment

Because of above right now it’s unusable as entry point for a Vue demo and a hazard if somebody wants to click on “Parent” from flask error while doing a generic distr. tracing demo. Additionally it’s making it impossible for me to verify whether se tag is set 100% of the time in the backend for all other supported frontends and transactions, which is now a requirement for capturing events for “mock data” streaming