### PR TITLE
[tda] sync file deletion/rename correctly when deploying TDA

### DIFF
--- a/tda/deploy_tda.sh
+++ b/tda/deploy_tda.sh
@@ -29,7 +29,7 @@ if ssh $HOST '[[ -d '"$DIR/env"' ]] && [[ ! -z `ls -A '"$DIR/env"'` ]]'; then
 fi
 
 echo "Copying code to remote directory..."
-rsync -rz --exclude env * .sauce_credentials $HOST:$DIR/
+rsync -rz --delete --exclude env * .sauce_credentials $HOST:$DIR/
 if [ $? != 0 ]; then
   echo "[ERROR] Failed to rsync code to remote directory."
   exit 1


### PR DESCRIPTION
As of right now if you delete or rename a code file it won't be deleted from deployment host. That's a problem when that file is a test, resulting unwanted test being run as pytest collects everything from directory