### PR TITLE
[React] Make browser profile frame human readable

### DIFF
--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -10,6 +10,62 @@ import { useState, useEffect } from 'react';
 function Products({ frontendSlowdown, backend }) {
   const [products, setProducts] = useState([]);
 
+  function determineProductsEndpoint() {
+    return frontendSlowdown ? '/products-join' : '/products';
+  }
+
+  function fetchUncompressedAsset() {
+    let uc_small_script = document.createElement('script');
+    uc_small_script.async = false;
+    uc_small_script.src =
+      backend +
+      '/compressed_assets/compressed_small_file.js' +
+      '?cacheBuster=' +
+      Math.random();
+    document.body.appendChild(uc_small_script);
+
+    // big uncompressed file
+    let c_big_script = document.createElement('script');
+    c_big_script.async = false;
+
+    c_big_script.src =
+      backend +
+      '/uncompressed_assets/uncompressed_big_file.js' +
+      '?cacheBuster=' +
+      Math.random();
+    document.body.appendChild(c_big_script);
+  }
+
+  // intentionally supposed to be slow
+  function renderProducts(data) {
+    try {
+      // Trigger a Sentry 'Performance Issue' in the case of
+      // a frontend slowdown
+      if (frontendSlowdown) {
+        // Must bust cache to have force transfer size
+        // small compressed file
+        fetchUncompressedAsset();
+
+        console.log('triggering slow render problem');
+        // When triggering a frontend-only slowdown, cause a slow render problem
+        setProducts(
+          Array(150) // 150 is arbitrary to make a slow enough render
+            .fill(data.slice(0, 4))
+            .flat()
+            .map((p, n) => {
+              p.id = n;
+              return p;
+            })
+        );
+      } else {
+        console.log('setting products quickly');
+        setProducts(data.slice(0, 4));
+      }
+    } catch (err) {
+      Sentry.captureException(new Error('app unable to load products: ' + err));
+    }
+  }
+
   useEffect(() => {
     // getProducts handles error responses differently, depending on the browser used
     function getProducts(frontendSlowdown) {
@@ -37,13 +93,9 @@ function Products({ frontendSlowdown, backend }) {
       // When triggering a frontend-only slowdown, use the products-join endpoint
       // because it returns product data with a fast backend response.
       // Otherwise use the /products endpoint, which provides a slow backend response.
-      const productsEndpoint = frontendSlowdown
-        ? '/products-join'
-        : '/products';
-      console.log(`productsEndpoint: ${productsEndpoint}`);
-      console.log(backend);
-      console.log(backend + productsEndpoint);
-      let result = fetch(backend + productsEndpoint, {
+      const productsEndpoint = determineProductsEndpoint();
+
+      fetch(backend + productsEndpoint, {
         method: 'GET',
         headers: {
           se,
@@ -53,8 +105,6 @@ function Products({ frontendSlowdown, backend }) {
         },
       })
         .then((result) => {
-          console.log('THE RESULTS::::::::::::');
-          console.log(result);
           if (!result.ok) {
             Sentry.configureScope(function (scope) {
               Sentry.setContext('err', {
@@ -67,66 +117,14 @@ function Products({ frontendSlowdown, backend }) {
             return result.json();
           }
         })
-        .then((data) => {
-          console.log('OKKKKK:::::');
-          console.log(data);
-          try {
-            // Trigger a Sentry 'Performance Issue' in the case of
-            // a frontend slowdown
-            if (frontendSlowdown) {
-              // Must bust cache to have force transfer size
-              // small compressed file
-              let uc_small_script = document.createElement('script');
-              uc_small_script.async = false;
-              uc_small_script.src =
-                backend +
-                '/compressed_assets/compressed_small_file.js' +
-                '?cacheBuster=' +
-                Math.random();
-              document.body.appendChild(uc_small_script);
-
-              // big uncompressed file
-              let c_big_script = document.createElement('script');
-              c_big_script.async = false;
-
-              c_big_script.src =
-                backend +
-                '/uncompressed_assets/uncompressed_big_file.js' +
-                '?cacheBuster=' +
-                Math.random();
-              document.body.appendChild(c_big_script);
-
-              console.log('triggering slow render problem');
-              // When triggering a frontend-only slowdown, cause a slow render problem
-              setProducts(
-                Array(200 / 4)
-                  .fill(data.slice(0, 4))
-                  .flat()
-                  .map((p, n) => {
-                    p.id = n;
-                    return p;
-                  })
-              );
-            } else {
-              console.log('setting products quickly');
-              setProducts(data.slice(0, 4));
-            }
-          } catch (err) {
-            Sentry.captureException(
-              new Error('app unable to load products: ' + err)
-            );
-          }
-        })
+        .then(renderProducts)
         .catch((err) => {
           return { ok: false, status: 500 };
         });
-      console.log('REAL RES::::::::');
-      console.log(result);
-      return result;
     }
 
     getProducts(frontendSlowdown);
-  }, [products, frontendSlowdown, backend]);
+  }, []);
 
   return products.length > 0 ? (
     <div>

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -1,32 +1,49 @@
 import { Component } from 'react';
-import Context from '../utils/context';
 import './products.css';
 import * as Sentry from '@sentry/react';
 import { connect } from 'react-redux';
 import { setProducts, addProduct } from '../actions';
 import Loader from 'react-loader-spinner';
-import { busy_sleep } from '../utils/time';
 import ProductCard from './ProductCard';
+import { useState, useEffect } from 'react';
 
-class Products extends Component {
-  static contextType = Context;
+function Products({ frontendSlowdown, backend }) {
+  const [products, setProducts] = useState([]);
 
-  constructor() {
-    super();
-    // makes the ui.react.mount span widen to 1500ms
-    // busy_sleep(1500)
-  }
+  useEffect(() => {
+    // getProducts handles error responses differently, depending on the browser used
+    function getProducts(frontendSlowdown) {
+      let se, customerType, email;
+      Sentry.withScope(function (scope) {
+        [se, customerType] = [scope._tags.se, scope._tags.customerType];
+        email = scope._user.email;
+      });
 
-  // getProducts handles error responses differently, depending on the browser used
-  async getProducts(frontendSlowdown) {
-    let se, customerType, email;
-    Sentry.withScope(function (scope) {
-      [se, customerType] = [scope._tags.se, scope._tags.customerType];
-      email = scope._user.email;
-    });
+      [('/api', '/connect', '/organization')].forEach((endpoint) => {
+        fetch(backend + endpoint, {
+          method: 'GET',
+          headers: {
+            se,
+            customerType,
+            email,
+            'Content-Type': 'application/json',
+          },
+        }).catch((err) => {
+          // If there's an error, it won't stop the Products http request and page from loading
+          Sentry.captureException(err);
+        });
+      });
 
-    [('/api', '/connect', '/organization')].forEach((endpoint) => {
-      fetch(this.props.backend + endpoint, {
+      // When triggering a frontend-only slowdown, use the products-join endpoint
+      // because it returns product data with a fast backend response.
+      // Otherwise use the /products endpoint, which provides a slow backend response.
+      const productsEndpoint = frontendSlowdown
+        ? '/products-join'
+        : '/products';
+      console.log(`productsEndpoint: ${productsEndpoint}`);
+      console.log(backend);
+      console.log(backend + productsEndpoint);
+      let result = fetch(backend + productsEndpoint, {
         method: 'GET',
         headers: {
           se,
@@ -34,130 +51,119 @@ class Products extends Component {
           email,
           'Content-Type': 'application/json',
         },
-      }).catch((err) => {
-        // If there's an error, it won't stop the Products http request and page from loading
-        Sentry.captureException(err);
-      });
-    });
-
-    // When triggering a frontend-only slowdown, use the products-join endpoint
-    // because it returns product data with a fast backend response.
-    // Otherwise use the /products endpoint, which provides a slow backend response.
-    const productsEndpoint = frontendSlowdown ? '/products-join' : '/products';
-    console.log(`productsEndpoint: ${productsEndpoint}`);
-    let result = await fetch(this.props.backend + productsEndpoint, {
-      method: 'GET',
-      method: 'GET',
-      headers: { se, customerType, email, 'Content-Type': 'application/json' },
-    }).catch((err) => {
-      return { ok: false, status: 500 };
-    });
-
-    if (!result.ok) {
-      Sentry.configureScope(function (scope) {
-        Sentry.setContext('err', {
-          status: result.status,
-          statusText: result.statusText,
-        });
-      });
-      return Promise.reject();
-    } else {
-      const jsonValue = await result.json();
-      return Promise.resolve(jsonValue);
-    }
-  }
-
-  async componentDidMount() {
-    var products;
-    try {
-      products = await this.getProducts(this.props.frontendSlowdown);
-
-      // Trigger a Sentry 'Performance Issue' in the case of
-      // a frontend slowdown
-      if (this.props.frontendSlowdown) {
-        // Must bust cache to have force transfer size
-        // small compressed file
-        let uc_small_script = document.createElement('script');
-        uc_small_script.async = false;
-        uc_small_script.src =
-          this.props.backend +
-          '/compressed_assets/compressed_small_file.js' +
-          '?cacheBuster=' +
-          Math.random();
-        document.body.appendChild(uc_small_script);
-
-        // big uncompressed file
-        let c_big_script = document.createElement('script');
-        c_big_script.async = false;
-
-        c_big_script.src =
-          this.props.backend +
-          '/uncompressed_assets/uncompressed_big_file.js' +
-          '?cacheBuster=' +
-          Math.random();
-        document.body.appendChild(c_big_script);
-
-        // When triggering a frontend-only slowdown, cause a slow render problem
-        this.props.setProducts(
-          Array(200 / 4)
-            .fill(products.slice(0, 4))
-            .flat()
-            .map((p, n) => {
-              p.id = n;
-              return p;
-            })
-        );
-      } else {
-        this.props.setProducts(products.slice(0, 4));
-      }
-    } catch (err) {
-      Sentry.captureException(new Error('app unable to load products: ' + err));
-    }
-  }
-
-  render() {
-    const { products } = this.props;
-    return products.length > 0 ? (
-      <div>
-        <ul className="products-list">
-          {products.map((product, i) => {
-            const averageRating = (
-              product.reviews.reduce((a, b) => a + (b['rating'] || 0), 0) /
-              product.reviews.length
-            ).toFixed(1);
-
-            let stars = [1, 2, 3, 4, 5].map((index) => {
-              if (index <= averageRating) {
-                return (
-                  <span className="star" key={index}>
-                    &#9733;
-                  </span>
-                );
-              } else {
-                return (
-                  <span className="star" key={index}>
-                    &#9734;
-                  </span>
-                );
-              }
+      })
+        .then((result) => {
+          console.log('THE RESULTS::::::::::::');
+          console.log(result);
+          if (!result.ok) {
+            Sentry.configureScope(function (scope) {
+              Sentry.setContext('err', {
+                status: result.status,
+                statusText: result.statusText,
+              });
             });
+            return Promise.reject();
+          } else {
+            return result.json();
+          }
+        })
+        .then((data) => {
+          console.log('OKKKKK:::::');
+          console.log(data);
+          try {
+            // Trigger a Sentry 'Performance Issue' in the case of
+            // a frontend slowdown
+            if (frontendSlowdown) {
+              // Must bust cache to have force transfer size
+              // small compressed file
+              let uc_small_script = document.createElement('script');
+              uc_small_script.async = false;
+              uc_small_script.src =
+                backend +
+                '/compressed_assets/compressed_small_file.js' +
+                '?cacheBuster=' +
+                Math.random();
+              document.body.appendChild(uc_small_script);
 
-            return (
-              <ProductCard
-                key={i}
-                product={product}
-                stars={stars}
-              ></ProductCard>
+              // big uncompressed file
+              let c_big_script = document.createElement('script');
+              c_big_script.async = false;
+
+              c_big_script.src =
+                backend +
+                '/uncompressed_assets/uncompressed_big_file.js' +
+                '?cacheBuster=' +
+                Math.random();
+              document.body.appendChild(c_big_script);
+
+              console.log('triggering slow render problem');
+              // When triggering a frontend-only slowdown, cause a slow render problem
+              setProducts(
+                Array(200 / 4)
+                  .fill(data.slice(0, 4))
+                  .flat()
+                  .map((p, n) => {
+                    p.id = n;
+                    return p;
+                  })
+              );
+            } else {
+              console.log('setting products quickly');
+              setProducts(data.slice(0, 4));
+            }
+          } catch (err) {
+            Sentry.captureException(
+              new Error('app unable to load products: ' + err)
             );
-          })}
-        </ul>
-      </div>
-    ) : (
-      <div className="loader-container">
-        <Loader type="ThreeDots" color="#f6cfb2" height={150} width={150} />
-      </div>
-    );
-  }
+          }
+        })
+        .catch((err) => {
+          return { ok: false, status: 500 };
+        });
+      console.log('REAL RES::::::::');
+      console.log(result);
+      return result;
+    }
+
+    getProducts(frontendSlowdown);
+  }, [products, frontendSlowdown, backend]);
+
+  return products.length > 0 ? (
+    <div>
+      <ul className="products-list">
+        {products.map((product, i) => {
+          const averageRating = (
+            product.reviews.reduce((a, b) => a + (b['rating'] || 0), 0) /
+            product.reviews.length
+          ).toFixed(1);
+
+          let stars = [1, 2, 3, 4, 5].map((index) => {
+            if (index <= averageRating) {
+              return (
+                <span className="star" key={index}>
+                  &#9733;
+                </span>
+              );
+            } else {
+              return (
+                <span className="star" key={index}>
+                  &#9734;
+                </span>
+              );
+            }
+          });
+
+          return (
+            <ProductCard key={i} product={product} stars={stars}></ProductCard>
+          );
+        })}
+      </ul>
+    </div>
+  ) : (
+    <div className="loader-container">
+      <Loader type="ThreeDots" color="#f6cfb2" height={150} width={150} />
+    </div>
+  );
 }
 
 const mapStateToProps = (state, ownProps) => {

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -66,6 +66,17 @@ function Products({ frontendSlowdown, backend }) {
     }
   }
 
+  /*
+    Fetching and setting the products used to be done in an
+    async componentDidMount function. We have (Nov 2023) changed the way of
+    doing this to be non-async, because the async function was getting minified in the
+    relevant browser profiling frame, and this made it hard to showcase profiling.
+
+    Jonas B explained why switching away from async function helped:
+    "I think what you are seeing is unrelated to hooks and probably
+    related to the async keyword + babel transform, hence why it probably got
+    fixed with hooks (no transform on that class method anymore)"
+  */
   useEffect(() => {
     // getProducts handles error responses differently, depending on the browser used
     function getProducts(frontendSlowdown) {


### PR DESCRIPTION
- addresses https://github.com/sentry-demos/empower/issues/306
- Replaces the cryptic `e` that is minified due to React limitations, with a human-readable `renderProducts()` function
- tested in staging ✅ 

⚠️ One thing that's not amazing is that we introduce [hooks](https://legacy.reactjs.org/docs/hooks-overview.html) to just one component in order to get this working. Whereas the other components in the app still do not use hooks. Hooks are modern React, and ideally we will rewrite all components in the app to use hooks -- which I wouldn't expect to be that difficult 🤞. But I think it's OK to rewrite components in phases, as general maintenance, and get this PR out there awhile.

## Before
<img width="692" alt="277014355-6bd822de-fd76-4f9e-aa93-531c9db2436b" src="https://github.com/sentry-demos/empower/assets/12092849/2ac3ebb7-4d68-4cfb-ad86-d2cfb7874a33">

## After
<img width="1790" alt="Screenshot 2023-11-27 at 3 25 19 PM" src="https://github.com/sentry-demos/empower/assets/12092849/996463e9-e975-4523-b9a9-21e2be66bfde">

## Tested on Staging
- [Transaction](https://demo.sentry.io/discover/staging-react:42511f28bc86492abb07d36d9c0d2b9e/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4504708328325120&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
- [Profile](https://demo.sentry.io/profiling/profile/staging-react/9c94716cf1f74dcb9167dc44d7c8d940/flamegraph/?colorCoding=by+system+vs+application+frame&query=&sorting=call+order&spanId=ba34607a72db7e7d&tid=0&view=top+down)
<img width="1792" alt="Screenshot 2023-11-27 at 3 43 20 PM" src="https://github.com/sentry-demos/empower/assets/12092849/2d30bf6c-9db1-4afd-8d69-ceac2432e016">

