### PR TITLE
perform db query on /organization 1% of the time

### DIFF
--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -1,6 +1,7 @@
 import datetime
 import operator
 import os
+import random
 import requests
 import time
 from flask import Flask, json, request, make_response, send_from_directory
@@ -117,7 +118,7 @@ def products():
     try:
         with sentry_sdk.start_span(op="/products.get_products", description="function"):
             rows = get_products()
-            
+
             if RUN_SLOW_PROFILE:
                 start_time = time.time()
                 productsJSON = json.loads(rows)
@@ -187,6 +188,10 @@ def api():
 
 @app.route('/organization', methods=['GET'])
 def organization():
+    # perform get_products db query 1% of time in order
+    #   to populate "Found In" endpoints in Queries
+    if random.random() < 0.01:
+        rows = get_products()
     return "flask /organization"
 
 @app.route('/connect', methods=['GET'])


### PR DESCRIPTION
Add a call to db.get_product in flask’s /organization endpoint so that we can get another “found in” endpoint on the query-summary page? Executes ~1% of the time /organization is hit.
https://github.com/sentry-demos/empower/blob/master/flask/src/main.py#L219-L221
https://github.com/sentry-demos/empower/blob/master/flask/src/db.py#L44

![image](https://github.com/sentry-demos/empower/assets/314061/d4956f32-8083-4c4d-a534-780fa7bc2d54)