### PR TITLE
[flask] bump Sentry SDK: 1.34.0 -> 1.37.1

### DIFF
--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -8,5 +8,5 @@ pg8000==1.12.5
 psycopg2-binary==2.9.7
 python-dotenv==0.12.0
 pytz==2020.4
-sentry-sdk==1.34.0
+sentry-sdk==1.37.1
 sqlalchemy==1.3.15


### PR DESCRIPTION
Motivation:
Hoping this fixes missing SE tag ([discover query](https://demo.sentry.io/discover/homepage/?end=2023-11-28T06%3A28%3A16&field=project&field=transaction&field=count%28%29&field=browser.name&field=client_os.name&field=event.type&id=21645&name=&project=5808655&query=count%28%29%3A%3E0+se%3A%22%22&sort=transaction&start=2023-11-28T05%3A28%3A16&topEvents=5&yAxis=count%28%29)) on some transactions even though [we set it for all routes using @app.before_request](https://github.com/sentry-demos/empower/blob/9d29e3714878497860d20cc0c518ce2e0ff5ce16/flask/src/main.py#L261C20-L265).


# Testing
```
./deploy.sh --env=staging flask
```
Filled out [Demo Data Requirements Matrix](https://www.notion.so/sentry/9366b129ce4745a7a40555a1d3b06467?v=02e3a592c3f543a79723158d9ad66953&pvs=4) based on current version, then checked `staging` against it (the ones that can be tested in staging)

[flagship error
](https://demo.sentry.io/issues/4676580638/?project=4504331063525376&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0)
[flagship transaction](https://demo.sentry.io/performance/staging-flask:66a92c16146d4798b3902a399e4a3781/?project=4504331063525376&query=http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=14d&transaction=products&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) 