### PR TITLE
[react][flask] fix missing SE tag for un/compressed_assets

### DIFF
--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -263,6 +263,12 @@ def sentry_event_context():
     se = request.headers.get('se')
     if se not in [None, "undefined"]:
         sentry_sdk.set_tag("se", se)
+    else:
+        # sometimes this is the only way to propagate, e.g. when requested through a dynamically
+        # inserted HTML tag as in case with (un)compressed_assets
+        se = request.args.get('se') 
+        if se not in [None, "undefined"]:
+            sentry_sdk.set_tag("se", se)
 
     customerType = request.headers.get('customerType')
     if customerType not in [None, "undefined"]:

--- a/react/src/components/Organization.js
+++ b/react/src/components/Organization.js
@@ -15,6 +15,9 @@ class Organization extends Component {
   }
 
   componentDidMount() {
+    let se; // `se` is automatically added to all fetch requests, but need to do manually for script tags
+    Sentry.withScope(function (scope) { se = scope._tags.se; });
+
     // Must bust cache to have force transfer size
     // small compressed file
     let uc_small_script = document.createElement('script');
@@ -22,8 +25,7 @@ class Organization extends Component {
     uc_small_script.src =
       this.props.backend +
       '/compressed_assets/compressed_small_file.js' +
-      '?cacheBuster=' +
-      Math.random();
+      `?cacheBuster=${Math.random()}&se=${se}`; 
     document.body.appendChild(uc_small_script);
 
     // big uncompressed file
@@ -33,8 +35,7 @@ class Organization extends Component {
     c_big_script.src =
       this.props.backend +
       '/uncompressed_assets/uncompressed_big_file.js' +
-      '?cacheBuster=' +
-      Math.random();
+      `?cacheBuster=${Math.random()}&se=${se}`; 
     document.body.appendChild(c_big_script);
   }
 

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -15,13 +15,15 @@ function Products({ frontendSlowdown, backend }) {
   }
 
   function fetchUncompressedAsset() {
+    let se; // `se` is automatically added to all fetch requests, but need to do manually for script tags
+    Sentry.withScope(function (scope) { se = scope._tags.se; });
+
     let uc_small_script = document.createElement('script');
     uc_small_script.async = false;
     uc_small_script.src =
       backend +
       '/compressed_assets/compressed_small_file.js' +
-      '?cacheBuster=' +
-      Math.random();
+      `?cacheBuster=${Math.random()}&se=${se}`; 
     document.body.appendChild(uc_small_script);
 
     // big uncompressed file
@@ -31,8 +33,7 @@ function Products({ frontendSlowdown, backend }) {
     c_big_script.src =
       backend +
       '/uncompressed_assets/uncompressed_big_file.js' +
-      '?cacheBuster=' +
-      Math.random();
+      `?cacheBuster=${Math.random()}&se=${se}`; 
     document.body.appendChild(c_big_script);
   }
 


### PR DESCRIPTION
The 2 flask endpoints corresponding to (un)compressed assets are missing SE tag ([discover query](https://demo.sentry.io/discover/homepage/?field=project&field=transaction&field=count%28%29&field=browser.name&field=client_os.name&field=event.type&field=sdk.version&id=21645&name=&project=5808655&query=se%3A%22%22+%21browser.name%3A%5Bokhttp%2CEmpowerPlant%2Csentry_react_native%5D&sort=transaction&statsPeriod=2h&topEvents=5&widths=-1&widths=277&yAxis=count%28%29))


# Testing
deployed react and flask to staging, 
hit /products and /organization with ?se=kosty in react
✅[send_report_configured_properly transaction](https://demo.sentry.io/performance/staging-flask:9718438469854d0a92390758c03e1e2e/?project=4504331063525376&query=http.method%3AGET&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=2h&transaction=send_report_configured_properly&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) has se tag set
✅[send_report transaction](https://demo.sentry.io/performance/staging-flask:b8e506899be94fc49a8f2619405ee2bd/?project=4504331063525376&query=http.method%3AGET&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=2h&transaction=send_report&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) has se tag set
❌ [not seeing any Uncompressed Asset performance issues](https://demo.sentry.io/issues/?project=4504708328325120&referrer=sidebar&statsPeriod=2h) @ndmanvar is that normal? does it need to meet some threshold on number of transactions?