### PR TITLE
[flask] reduce /get_iterator span from 4s to 2s to fudge LCP p75

### DIFF
--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -155,11 +155,11 @@ def products():
                 descriptions = [product["description"] for product in productsJSON]
                 with sentry_sdk.start_span(op="/get_iterator", description="function"):
                     with sentry_sdk.metrics.timing(key="products.get_iterator.execution_time"):
-                        loop = get_iterator(len(descriptions) * 6)
+                        loop = get_iterator(len(descriptions) * 6 - 1)
 
                     for i in range(loop):
                         time_delta = time.time() - start_time
-                        if time_delta > 4:
+                        if time_delta > 2:
                             break
 
                         for i, description in enumerate(descriptions):


### PR DESCRIPTION
Make `get_iterator` faster by 2 seconds needed to bring down React LCP p75 down to 5.5s from 7.5s so that the horizontal line in web vitals corresponding to LCP on the right has some thickness to it and looks good in the demo.

<img width="1137" alt="Screenshot 2023-12-12 at 10 09 23 PM" src="https://github.com/sentry-demos/empower/assets/490201/094c4989-b9d7-4df3-99a7-7433f3d6ef20">
