### PR TITLE
Update to sentry-python 1.39.2 to fix GH linking in Query Source

### DIFF
--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -8,5 +8,5 @@ pg8000==1.12.5
 psycopg2-binary==2.9.7
 python-dotenv==0.12.0
 pytz==2020.4
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
 sqlalchemy==1.3.15


### PR DESCRIPTION
Update `sentry-python` to `1.39.2` in order to fix missing GH linking on Query Source ([example](https://demo.sentry.io/performance/database/spans/span/496db2bc74e1e116/?project=5808655&statsPeriod=1h))

After the update, it looks like [this](https://demo.sentry.io/performance/database/spans/span/44fb837cac2f206c/?project=5808655&statsPeriod=1h)

<img width="1477" alt="Screenshot 2024-01-15 at 2 44 53 PM" src="https://github.com/sentry-demos/empower/assets/109162568/dca52dea-57f8-4ff0-8144-68f17dafe77b">

<img width="1340" alt="Screenshot 2024-01-15 at 2 47 05 PM" src="https://github.com/sentry-demos/empower/assets/109162568/5b7cf90c-475a-49c2-ace3-2025f17787c0">

