### PR TITLE
webvitals-fix: update sentry js sdk to 7.98.0

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "application-monitoring",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "~7.93.0",
+        "@sentry/react": "~7.98.0",
         "@testing-library/jest-dom": "~5.11.4",
         "@testing-library/react": "~11.1.0",
         "@testing-library/user-event": "~12.1.10",
@@ -2346,135 +2346,181 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.93.0.tgz",
-      "integrity": "sha512-4G7rMeQbYGfCHxEoFroABX+UREYc2BSbFqjLmLbIcWowSpgzcwweLLphWHKOciqK6f7DnNDK0jZzx3u7NrkWHw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.98.0.tgz",
+      "integrity": "sha512-t/mATvwkLcQLKRlx8SO5vlUjaadF6sT3lfR0PdWYyBy8qglbMTHDW4KP6JKh1gdzTVQGnwMByy+/4h9gy4AVzw==",
       "dependencies": {
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-      "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+      "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
       "dependencies": {
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-      "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+      "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/feedback/node_modules/@sentry/utils": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-      "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+      "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
       "dependencies": {
-        "@sentry/types": "7.93.0"
+        "@sentry/types": "7.98.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.98.0.tgz",
+      "integrity": "sha512-vAR6KIycyazaY9HwxG5UONrPTe8jeKtZr6k04svPC8OvcoI0xF+l1jMEYcarffuzKpZlPfssYb5ChHtKuXCB+Q==",
+      "dependencies": {
+        "@sentry/core": "7.98.0",
+        "@sentry/replay": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+      "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
+      "dependencies": {
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+      "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/utils": {
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+      "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
+      "dependencies": {
+        "@sentry/types": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.93.0.tgz",
-      "integrity": "sha512-DjuhmQNywPp+8fxC9dvhGrqgsUb6wI/HQp25lS2Re7VxL1swCasvpkg8EOYP4iBniVQ86QK0uITkOIRc5tdY1w==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.98.0.tgz",
+      "integrity": "sha512-FnhD2uMLIAJvv4XsYPv3qsTTtxrImyLxiZacudJyaWFhxoeVQ8bKKbWJ/Ar68FAwqTtjXMeY5evnEBbRMcQlaA==",
       "dependencies": {
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-      "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+      "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
       "dependencies": {
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-      "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+      "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-      "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+      "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
       "dependencies": {
-        "@sentry/types": "7.93.0"
+        "@sentry/types": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.93.0.tgz",
-      "integrity": "sha512-MtLTcQ7y3rfk+aIvnnwCfSJvYhTJnIJi+Mf6y/ap6SKObdlsKMbQoJLlRViglGLq+nKxHLAvU0fONiCEmKfV6A==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.98.0.tgz",
+      "integrity": "sha512-/MzTS31N2iM6Qwyh4PSpHihgmkVD5xdfE5qi1mTlwQZz5Yz8t7MdMriX8bEDPlLB8sNxl7+D6/+KUJO8akX0nQ==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.93.0",
-        "@sentry-internal/tracing": "7.93.0",
-        "@sentry/core": "7.93.0",
-        "@sentry/replay": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry-internal/feedback": "7.98.0",
+        "@sentry-internal/replay-canvas": "7.98.0",
+        "@sentry-internal/tracing": "7.98.0",
+        "@sentry/core": "7.98.0",
+        "@sentry/replay": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/core": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-      "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+      "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
       "dependencies": {
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/types": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-      "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+      "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/utils": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-      "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+      "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
       "dependencies": {
-        "@sentry/types": "7.93.0"
+        "@sentry/types": "7.98.0"
       },
       "engines": {
         "node": ">=8"
@@ -2749,14 +2795,14 @@
       "dev": true
     },
     "node_modules/@sentry/react": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.93.0.tgz",
-      "integrity": "sha512-B0bzziV1lEyN7xd0orUPyJdpoK6CtcyodmQkfY0WsHLm/1d9xi95M05lObHnsMWO1js6c9B9d9kO8RlKFz947A==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.98.0.tgz",
+      "integrity": "sha512-rTvsAaGPuOGm2FvJAD8aB7iE+rUIrwYWKT4gANvg8zxRzPCK7ukKkpmL3SeJi7bvLNHYLATl1hUVDgm8VpHDng==",
       "dependencies": {
-        "@sentry/browser": "7.93.0",
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0",
+        "@sentry/browser": "7.98.0",
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -2767,76 +2813,76 @@
       }
     },
     "node_modules/@sentry/react/node_modules/@sentry/core": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-      "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+      "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
       "dependencies": {
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react/node_modules/@sentry/types": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-      "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+      "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react/node_modules/@sentry/utils": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-      "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+      "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
       "dependencies": {
-        "@sentry/types": "7.93.0"
+        "@sentry/types": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.93.0.tgz",
-      "integrity": "sha512-dMlLU8v+OkUeGCrPvTu5NriH7BGj3el4rGHWWAYicfJ2QXqTTq50vfasQBP1JeVNcFqnf1y653TdEIvo4RH4tw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.98.0.tgz",
+      "integrity": "sha512-CQabv/3KnpMkpc2TzIquPu5krpjeMRAaDIO0OpTj5SQeH2RqSq3fVWNZkHa8tLsADxcfLFINxqOg2jd1NxvwxA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.93.0",
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry-internal/tracing": "7.98.0",
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/replay/node_modules/@sentry/core": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-      "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+      "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
       "dependencies": {
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay/node_modules/@sentry/types": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-      "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+      "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay/node_modules/@sentry/utils": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-      "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+      "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
       "dependencies": {
-        "@sentry/types": "7.93.0"
+        "@sentry/types": "7.98.0"
       },
       "engines": {
         "node": ">=8"
@@ -21646,106 +21692,142 @@
       }
     },
     "@sentry-internal/feedback": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.93.0.tgz",
-      "integrity": "sha512-4G7rMeQbYGfCHxEoFroABX+UREYc2BSbFqjLmLbIcWowSpgzcwweLLphWHKOciqK6f7DnNDK0jZzx3u7NrkWHw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.98.0.tgz",
+      "integrity": "sha512-t/mATvwkLcQLKRlx8SO5vlUjaadF6sT3lfR0PdWYyBy8qglbMTHDW4KP6JKh1gdzTVQGnwMByy+/4h9gy4AVzw==",
       "requires": {
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-          "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+          "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
           "requires": {
-            "@sentry/types": "7.93.0",
-            "@sentry/utils": "7.93.0"
+            "@sentry/types": "7.98.0",
+            "@sentry/utils": "7.98.0"
           }
         },
         "@sentry/types": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-          "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw=="
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+          "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ=="
         },
         "@sentry/utils": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-          "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+          "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
           "requires": {
-            "@sentry/types": "7.93.0"
+            "@sentry/types": "7.98.0"
+          }
+        }
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.98.0.tgz",
+      "integrity": "sha512-vAR6KIycyazaY9HwxG5UONrPTe8jeKtZr6k04svPC8OvcoI0xF+l1jMEYcarffuzKpZlPfssYb5ChHtKuXCB+Q==",
+      "requires": {
+        "@sentry/core": "7.98.0",
+        "@sentry/replay": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+          "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
+          "requires": {
+            "@sentry/types": "7.98.0",
+            "@sentry/utils": "7.98.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+          "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ=="
+        },
+        "@sentry/utils": {
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+          "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
+          "requires": {
+            "@sentry/types": "7.98.0"
           }
         }
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.93.0.tgz",
-      "integrity": "sha512-DjuhmQNywPp+8fxC9dvhGrqgsUb6wI/HQp25lS2Re7VxL1swCasvpkg8EOYP4iBniVQ86QK0uITkOIRc5tdY1w==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.98.0.tgz",
+      "integrity": "sha512-FnhD2uMLIAJvv4XsYPv3qsTTtxrImyLxiZacudJyaWFhxoeVQ8bKKbWJ/Ar68FAwqTtjXMeY5evnEBbRMcQlaA==",
       "requires": {
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-          "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+          "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
           "requires": {
-            "@sentry/types": "7.93.0",
-            "@sentry/utils": "7.93.0"
+            "@sentry/types": "7.98.0",
+            "@sentry/utils": "7.98.0"
           }
         },
         "@sentry/types": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-          "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw=="
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+          "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ=="
         },
         "@sentry/utils": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-          "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+          "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
           "requires": {
-            "@sentry/types": "7.93.0"
+            "@sentry/types": "7.98.0"
           }
         }
       }
     },
     "@sentry/browser": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.93.0.tgz",
-      "integrity": "sha512-MtLTcQ7y3rfk+aIvnnwCfSJvYhTJnIJi+Mf6y/ap6SKObdlsKMbQoJLlRViglGLq+nKxHLAvU0fONiCEmKfV6A==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.98.0.tgz",
+      "integrity": "sha512-/MzTS31N2iM6Qwyh4PSpHihgmkVD5xdfE5qi1mTlwQZz5Yz8t7MdMriX8bEDPlLB8sNxl7+D6/+KUJO8akX0nQ==",
       "requires": {
-        "@sentry-internal/feedback": "7.93.0",
-        "@sentry-internal/tracing": "7.93.0",
-        "@sentry/core": "7.93.0",
-        "@sentry/replay": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry-internal/feedback": "7.98.0",
+        "@sentry-internal/replay-canvas": "7.98.0",
+        "@sentry-internal/tracing": "7.98.0",
+        "@sentry/core": "7.98.0",
+        "@sentry/replay": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-          "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+          "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
           "requires": {
-            "@sentry/types": "7.93.0",
-            "@sentry/utils": "7.93.0"
+            "@sentry/types": "7.98.0",
+            "@sentry/utils": "7.98.0"
           }
         },
         "@sentry/types": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-          "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw=="
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+          "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ=="
         },
         "@sentry/utils": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-          "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+          "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
           "requires": {
-            "@sentry/types": "7.93.0"
+            "@sentry/types": "7.98.0"
           }
         }
       }
@@ -21948,72 +22030,72 @@
       }
     },
     "@sentry/react": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.93.0.tgz",
-      "integrity": "sha512-B0bzziV1lEyN7xd0orUPyJdpoK6CtcyodmQkfY0WsHLm/1d9xi95M05lObHnsMWO1js6c9B9d9kO8RlKFz947A==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.98.0.tgz",
+      "integrity": "sha512-rTvsAaGPuOGm2FvJAD8aB7iE+rUIrwYWKT4gANvg8zxRzPCK7ukKkpmL3SeJi7bvLNHYLATl1hUVDgm8VpHDng==",
       "requires": {
-        "@sentry/browser": "7.93.0",
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0",
+        "@sentry/browser": "7.98.0",
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-          "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+          "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
           "requires": {
-            "@sentry/types": "7.93.0",
-            "@sentry/utils": "7.93.0"
+            "@sentry/types": "7.98.0",
+            "@sentry/utils": "7.98.0"
           }
         },
         "@sentry/types": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-          "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw=="
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+          "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ=="
         },
         "@sentry/utils": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-          "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+          "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
           "requires": {
-            "@sentry/types": "7.93.0"
+            "@sentry/types": "7.98.0"
           }
         }
       }
     },
     "@sentry/replay": {
-      "version": "7.93.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.93.0.tgz",
-      "integrity": "sha512-dMlLU8v+OkUeGCrPvTu5NriH7BGj3el4rGHWWAYicfJ2QXqTTq50vfasQBP1JeVNcFqnf1y653TdEIvo4RH4tw==",
+      "version": "7.98.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.98.0.tgz",
+      "integrity": "sha512-CQabv/3KnpMkpc2TzIquPu5krpjeMRAaDIO0OpTj5SQeH2RqSq3fVWNZkHa8tLsADxcfLFINxqOg2jd1NxvwxA==",
       "requires": {
-        "@sentry-internal/tracing": "7.93.0",
-        "@sentry/core": "7.93.0",
-        "@sentry/types": "7.93.0",
-        "@sentry/utils": "7.93.0"
+        "@sentry-internal/tracing": "7.98.0",
+        "@sentry/core": "7.98.0",
+        "@sentry/types": "7.98.0",
+        "@sentry/utils": "7.98.0"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.93.0.tgz",
-          "integrity": "sha512-vZQSUiDn73n+yu2fEcH+Wpm4GbRmtxmnXnYCPgM6IjnXqkVm3awWAkzrheADblx3kmxrRiOlTXYHw9NTWs56fg==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.98.0.tgz",
+          "integrity": "sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==",
           "requires": {
-            "@sentry/types": "7.93.0",
-            "@sentry/utils": "7.93.0"
+            "@sentry/types": "7.98.0",
+            "@sentry/utils": "7.98.0"
           }
         },
         "@sentry/types": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.93.0.tgz",
-          "integrity": "sha512-UnzUccNakhFRA/esWBWP+0v7cjNg+RilFBQC03Mv9OEMaZaS29zSbcOGtRzuFOXXLBdbr44BWADqpz3VW0XaNw=="
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.98.0.tgz",
+          "integrity": "sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ=="
         },
         "@sentry/utils": {
-          "version": "7.93.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.93.0.tgz",
-          "integrity": "sha512-Iovj7tUnbgSkh/WrAaMrd5UuYjW7AzyzZlFDIUrwidsyIdUficjCG2OIxYzh76H6nYIx9SxewW0R54Q6XoB4uA==",
+          "version": "7.98.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.98.0.tgz",
+          "integrity": "sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==",
           "requires": {
-            "@sentry/types": "7.93.0"
+            "@sentry/types": "7.98.0"
           }
         }
       }

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "~7.93.0",
+    "@sentry/react": "~7.98.0",
     "@testing-library/jest-dom": "~5.11.4",
     "@testing-library/react": "~11.1.0",
     "@testing-library/user-event": "~12.1.10",


### PR DESCRIPTION
starting from version [7.96.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.96.0), the latest Sentry Javascript SDK now includes a fix to capture LCP and CLS more often. This will also result in more results and performance scores showing up in the Web Vitals module