### PR TITLE
add two seconds to see if that helps with webvitals issue

### DIFF
--- a/tda/.sauce_credentials
+++ b/tda/.sauce_credentials
@@ -1,3 +1,0 @@
-export SAUCE_USERNAME=sentry-sales-engineering
-export SAUCE_ACCESS_KEY=602fbac7-ee56-4da0-9814-d098ea3bc6fe
-

--- a/tda/.sauce_credentials
+++ b/tda/.sauce_credentials
@@ -1,0 +1,3 @@
+export SAUCE_USERNAME=sentry-sales-engineering
+export SAUCE_ACCESS_KEY=602fbac7-ee56-4da0-9814-d098ea3bc6fe
+

--- a/tda/desktop_web/test_checkout.py
+++ b/tda/desktop_web/test_checkout.py
@@ -25,6 +25,11 @@ def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sl
             try:
                 desktop_web_driver.get(url)
 
+                # Add 2 second sleep between the initial /products pageload
+                #   and the navigation to the checkout cart
+                #   to solve for web vitals issue as transaction may not be resolving
+                time.sleep(2)
+
                 # Optional - use the time.sleep here so button can rinish rendering before the desktop_web_driver tries to click it
                 # Solution - handle gracefully when the desktop_web_driver clicks a button that's not rendered yet, and then time.sleep(1) and try again
                 # time.sleep(5)


### PR DESCRIPTION
From the devs:
> I have a wild guess, but would it be possible to add some timeout (maybe 2 seconds) between the initial /products page load and the navigation to the checkout cart?

> The issue might have something to do with transaction boundaries + selenium. I notice that there's no issue on the /products when using my own browser.

> if you take a look at this replay, it looks like the navigation to /cart happens immediately after the /products page is loaded and the sdk doesnt have any time to resolve the pageload transaction https://demo.sentry.io/replays/98f5eaa4fa86415e963b2b89ef6f3839/?referrer=%2Fperformance%2F%3AeventSlug%2F&t=5.901&t_main=network

Neil: yep, let me try this