### PR TITLE
update python-sdk to 1.40.0 to fix query-source (now on by default)

### DIFF
--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -8,5 +8,5 @@ pg8000==1.12.5
 psycopg2-binary==2.9.7
 python-dotenv==0.12.0
 pytz==2020.4
-sentry-sdk==1.39.2
+sentry-sdk==1.40.0
 sqlalchemy==1.3.15

--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -75,7 +75,6 @@ class MyFlask(Flask):
             traces_sample_rate=1.0,
             before_send=before_send,
             traces_sampler=traces_sampler,
-            enable_db_query_source=True,
             _experiments={
                 "enable_metrics": True,
                 "profiles_sample_rate": 1.0
@@ -273,7 +272,7 @@ def sentry_event_context():
     else:
         # sometimes this is the only way to propagate, e.g. when requested through a dynamically
         # inserted HTML tag as in case with (un)compressed_assets
-        se = request.args.get('se') 
+        se = request.args.get('se')
         if se not in [None, "undefined"]:
             sentry_sdk.set_tag("se", se)
 


### PR DESCRIPTION
> we fixed the bug with query source not being attached to some spans & we turned collecting query source on by default in [Python SDK 1.40.0](https://github.com/getsentry/sentry-python/releases/tag/1.40.0).