### PR TITLE
Remove experimental feature for ui clicks, which may be overwriting navigation transactions

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -104,7 +104,9 @@ Sentry.init({
       },
       _experiments: {
         // This enables tracing on user interactions like clicks
-        //  --> disabling experimental interactions feature
+        //  --> 2/13/24 disabling experimental interactions feature
+        //      because it may be preventing navigation transactions
+        //      from being captured
         enableInteractions: false,
         // This enables profiling of route transactions in react
         onStartRouteTransaction: Sentry.onProfilingStartRouteTransaction,

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -104,7 +104,8 @@ Sentry.init({
       },
       _experiments: {
         // This enables tracing on user interactions like clicks
-        enableInteractions: true,
+        //  --> disabling experimental interactions feature
+        enableInteractions: false,
         // This enables profiling of route transactions in react
         onStartRouteTransaction: Sentry.onProfilingStartRouteTransaction,
       },


### PR DESCRIPTION
# Description

experimental feature ui.click transactions may be overwriting navigation transactions in the demo. 

Abhi: 
> perhaps theres a race condition here. Considering ui interactions are experimental and not actively supported, should we turn this off for the demo?


## Slack discussion for context

**Will C (Wed Jan 24 2024)**
Can anyone fill me on on what the ui.action.click for /products is about?
or link me to a PullRequest?
I opened it, it appears like a pageload txn, it has spans you’d find in a pageload
![image (73)](https://github.com/sentry-demos/empower/assets/12092849/4d1291af-f73d-4d44-9c7d-89deb4e6e28f)


22 replies
**Will C**
  
The TPM indicates it’s probably being done via TDA, is that the case?
Not asking for either of the /products /products to be removed.
Just looking to be aware of any potential differences or plans regarding demo’s or the architecture of our app.

**Kosty M**  
weird

**Chris S**
Probably this? https://github.com/getsentry/sentry-javascript/issues/5750
Edit: nvm, looks like it is still open: https://github.com/getsentry/sentry-javascript/discussions/6941 (edited) 
🥔
1

**Kosty M**
interesting how navigation is still there but is a tiny fraction by TPM/#of users
and it’s not coming from an old SDK: [https://demo.sentry.io/discover/homepage/?display=default&field=sdk.version&field=tr[…]n%3A%2Fproducts&sort=-sdk.version&statsPeriod=24h&topEvents=5](https://demo.sentry.io/discover/homepage/?display=default&field=sdk.version&field=transaction.op&field=count%28%29&id=21645&name=&project=5808623&query=transaction%3A%2Fproducts&sort=-sdk.version&statsPeriod=24h&topEvents=5)

**Chris S**  
If we don’t care to find out why right now: https://github.com/sentry-demos/empower/pull/383

**Chris S**
Could also scope the filter just to /products ui.action.clicks

**Kosty M**
It seems like ui.action.click is supposed to replace navigation . We should probably check with Abhi why navigation are still trickling in occasionally… or am I missing something?

**Chris S**  
Ah. My bad, did not digest what you were saying 
👍
We should probably check with Abhi why navigation are still trickling in occasionally…
agree 
👍

**Chris S**  
Did anyone hear anything about navigation going away?

**Chris S**  
Still getting a lot of navigation tx in [sentry.sentry.io](http://sentry.sentry.io/) from a higher sdk ver
[https://sentry.sentry.io/discover/homepage/?field=sdk.version&field=transaction.op&fi[…]vigation&sort=-sdk.version&statsPeriod=14d&yAxis=count%28%29](https://sentry.sentry.io/discover/homepage/?field=sdk.version&field=transaction.op&field=project&field=transaction&name=All+Events&project=11276&query=transaction.op%3Anavigation&sort=-sdk.version&statsPeriod=14d&yAxis=count%28%29)

**Chris S**  
[@abhi](https://sentry.slack.com/team/UN3ES0284)
 we wanted to ask your opinion about something (not urgent).
Summarizing the discussion above:
We used to have a high volume of navigation transactions in our demo. We now see a [high volume](https://demo.sentry.io/discover/homepage/?display=default&field=sdk.version&field=transaction.op&field=count%28%29&id=21645&project=5808623&query=transaction%3A%2Fproducts+transaction.op%3Aui.action.click&sort=-sdk.version&statsPeriod=90d&topEvents=5) of ui.action.click and a [small handful](https://demo.sentry.io/discover/homepage/?display=default&field=sdk.version&field=transaction.op&field=count%28%29&id=21645&project=5808623&query=transaction%3A%2Fproducts+transaction.op%3Anavigation&sort=-sdk.version&statsPeriod=90d&topEvents=5) of navigation transactions.
This has been happening for >90 days so hard to tell what might have introduced it.
Any idea why this would have happened? Did ui.action.click replace navigation transactions at some point not that long ago?
We saw these GH discussions ([1](https://github.com/getsentry/sentry-javascript/discussions/6941), [2](https://github.com/getsentry/sentry-javascript/issues/5750)) you were involved in, but seems like (a) this may not be implemented yet, and (b) it’s opt-in. So this seems unlikely to me?

**Abhijeet P**  
ui.action.click is enabled by adding the experiment https://github.com/sentry-demos/empower/blob/d509baf0814844a17a2c87243a8e878f88ec28fe/react/src/index.js#L106-L107

:thank_you:
1

🥔
1

**Abhijeet P**
but it shouldn’t replace anything, we didn’t make any changes on the SDK side toward this

**Kosty M**  
🤔
 I don’t get it… It looks like the overwhelming majority of what used to be op:navigation txns are now op:ui.action.click which seems to be the definition of replacing

**Abhijeet P**
we have logic builtin to prevent interactions from overwriting navigations https://github.com/getsentry/sentry-javascript/blob/52495c00ba700dd1df58025ef49195048279b692/packages/tracing-internal/src/browser/browsertracing.ts#L422-L425

**Abhijeet P**  
Also I see a lot of this is on 7.77.0 - can we try bumping the SDK to 7.94.1?
:baymax-yes:
1

**Kosty M**  
also I wonder if those are history i.e. clicking 
⬅️
 in the browser
see how not a single one is from TDA: [https://demo.sentry.io/discover/homepage/?display=default&field=sdk.version&field=tr[…]%3Anavigation&sort=transaction.op&statsPeriod=14d&topEvents=5](https://demo.sentry.io/discover/homepage/?display=default&field=sdk.version&field=transaction.op&field=count%28%29&field=se&id=21645&name=&project=5808623&query=transaction%3A%2Fproducts+transaction.op%3Anavigation&sort=transaction.op&statsPeriod=14d&topEvents=5)

**Abhijeet P**
also I wonder if those are history i.e. clicking 
⬅️
 in the browser
does the automation trigger the a button click instead of history navigate?

**Kosty M**
I believe so. New selenium session load the page (pageload) then clicking

**Abhijeet P**  
so that should trigger navigate first, but perhaps theres a race condition here. Considering ui interactions are experimental and not actively supported, should we turn this off for the demo?

👍
1