### PR TITLE
[react] fix Dockerfile for mock data

### DIFF
--- a/react/Dockerfile
+++ b/react/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster-slim
+FROM node:18.19.1-buster-slim
 
 RUN npm install -g serve
 


### PR DESCRIPTION
This should fix mock-data check broken when upgrading Node 16 -> 18 earlier