### PR TITLE
Bumps sentry react sdk to 7.108.0 and toggle enableInp to true

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "application-monitoring",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "~7.99.0",
+        "@sentry/react": "~7.108.0",
         "@testing-library/jest-dom": "~5.11.4",
         "@testing-library/react": "~11.1.0",
         "@testing-library/user-event": "~12.1.10",
@@ -30,7 +30,7 @@
       },
       "engines": {
         "node": ">=18.0.0 <19.0.0",
-        "npm": ">=8.0.0 <9.0.0"
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3634,40 +3634,40 @@
       "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA=="
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.99.0.tgz",
-      "integrity": "sha512-exIO1o+bE0MW4z30FxC0cYzJ4ZHSMlDPMHCBDPzU+MWGQc/fb8s58QUrx5Dnm6HTh9G3H+YlroCxIo9u0GSwGQ==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.108.0.tgz",
+      "integrity": "sha512-8JcgZEnk1uWrXJhsd3iRvFtEiVeaWOEhN0NZwhwQXHfvODqep6JtrkY1yCIyxbpA37aZmrPc2JhyotRERGfUjg==",
       "dependencies": {
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.99.0.tgz",
-      "integrity": "sha512-PoIkfusToDq0snfl2M6HJx/1KJYtXxYhQplrn11kYadO04SdG0XGXf4h7wBTMEQ7LDEAtQyvsOu4nEQtTO3YjQ==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.108.0.tgz",
+      "integrity": "sha512-R5tvjGqWUV5vSk0N1eBgVW7wIADinrkfDEBZ9FyKP2mXHBobsyNGt30heJDEqYmVqluRqjU2NuIRapsnnrpGnA==",
       "dependencies": {
-        "@sentry/core": "7.99.0",
-        "@sentry/replay": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/core": "7.108.0",
+        "@sentry/replay": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.99.0.tgz",
-      "integrity": "sha512-z3JQhHjoM1KdM20qrHwRClKJrNLr2CcKtCluq7xevLtXHJWNAQQbafnWD+Aoj85EWXBzKt9yJMv2ltcXJ+at+w==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.108.0.tgz",
+      "integrity": "sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==",
       "dependencies": {
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       },
       "engines": {
         "node": ">=8"
@@ -3683,17 +3683,17 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.99.0.tgz",
-      "integrity": "sha512-bgfoUv3wkwwLgN5YUOe0ibB3y268ZCnamZh6nLFqnY/UBKC1+FXWFdvzVON/XKUm62LF8wlpCybOf08ebNj2yg==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.108.0.tgz",
+      "integrity": "sha512-FNpzsdTvGvdHJMUelqEouUXMZU7jC+dpN7CdT6IoHVVFEkoAgrjMVUhXZoQ/dmCkdKWHmFSQhJ8Fm6V+e9Aq0A==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.99.0",
-        "@sentry-internal/replay-canvas": "7.99.0",
-        "@sentry-internal/tracing": "7.99.0",
-        "@sentry/core": "7.99.0",
-        "@sentry/replay": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry-internal/feedback": "7.108.0",
+        "@sentry-internal/replay-canvas": "7.108.0",
+        "@sentry-internal/tracing": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/replay": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       },
       "engines": {
         "node": ">=8"
@@ -3935,26 +3935,26 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
-      "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.108.0.tgz",
+      "integrity": "sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==",
       "dependencies": {
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.99.0.tgz",
-      "integrity": "sha512-RtHwgzMHJhzJfSQpVG0SDPQYMTGDX3Q37/YWI59S4ALMbSW4/F6n/eQAvGVYZKbh2UCSqgFuRWaXOYkSZT17wA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.108.0.tgz",
+      "integrity": "sha512-C60arh5/gtO42eMU9l34aWlKDLZUO+1j1goaEf/XRSwUcyJS9tbJrs+mT4nbKxUsEG714It2gRbfSEvh1eXmCg==",
       "dependencies": {
-        "@sentry/browser": "7.99.0",
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0",
+        "@sentry/browser": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -3965,33 +3965,33 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.99.0.tgz",
-      "integrity": "sha512-gyN/I2WpQrLAZDT+rScB/0jnFL2knEVBo8U8/OVt8gNP20Pq8T/rDZKO/TG0cBfvULDUbJj2P4CJryn2p/O2rA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.108.0.tgz",
+      "integrity": "sha512-jo8fDOzcZJclP1+4n9jUtVxTlBFT9hXwxhAMrhrt70FV/nfmCtYQMD3bzIj79nwbhUtFP6pN39JH1o7Xqt1hxQ==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.99.0",
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry-internal/tracing": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
-      "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.108.0.tgz",
+      "integrity": "sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
-      "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.108.0.tgz",
+      "integrity": "sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==",
       "dependencies": {
-        "@sentry/types": "7.99.0"
+        "@sentry/types": "7.108.0"
       },
       "engines": {
         "node": ">=8"
@@ -21822,34 +21822,34 @@
       "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA=="
     },
     "@sentry-internal/feedback": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.99.0.tgz",
-      "integrity": "sha512-exIO1o+bE0MW4z30FxC0cYzJ4ZHSMlDPMHCBDPzU+MWGQc/fb8s58QUrx5Dnm6HTh9G3H+YlroCxIo9u0GSwGQ==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.108.0.tgz",
+      "integrity": "sha512-8JcgZEnk1uWrXJhsd3iRvFtEiVeaWOEhN0NZwhwQXHfvODqep6JtrkY1yCIyxbpA37aZmrPc2JhyotRERGfUjg==",
       "requires": {
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.99.0.tgz",
-      "integrity": "sha512-PoIkfusToDq0snfl2M6HJx/1KJYtXxYhQplrn11kYadO04SdG0XGXf4h7wBTMEQ7LDEAtQyvsOu4nEQtTO3YjQ==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.108.0.tgz",
+      "integrity": "sha512-R5tvjGqWUV5vSk0N1eBgVW7wIADinrkfDEBZ9FyKP2mXHBobsyNGt30heJDEqYmVqluRqjU2NuIRapsnnrpGnA==",
       "requires": {
-        "@sentry/core": "7.99.0",
-        "@sentry/replay": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/core": "7.108.0",
+        "@sentry/replay": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.99.0.tgz",
-      "integrity": "sha512-z3JQhHjoM1KdM20qrHwRClKJrNLr2CcKtCluq7xevLtXHJWNAQQbafnWD+Aoj85EWXBzKt9yJMv2ltcXJ+at+w==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.108.0.tgz",
+      "integrity": "sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==",
       "requires": {
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/babel-plugin-component-annotate": {
@@ -21859,17 +21859,17 @@
       "dev": true
     },
     "@sentry/browser": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.99.0.tgz",
-      "integrity": "sha512-bgfoUv3wkwwLgN5YUOe0ibB3y268ZCnamZh6nLFqnY/UBKC1+FXWFdvzVON/XKUm62LF8wlpCybOf08ebNj2yg==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.108.0.tgz",
+      "integrity": "sha512-FNpzsdTvGvdHJMUelqEouUXMZU7jC+dpN7CdT6IoHVVFEkoAgrjMVUhXZoQ/dmCkdKWHmFSQhJ8Fm6V+e9Aq0A==",
       "requires": {
-        "@sentry-internal/feedback": "7.99.0",
-        "@sentry-internal/replay-canvas": "7.99.0",
-        "@sentry-internal/tracing": "7.99.0",
-        "@sentry/core": "7.99.0",
-        "@sentry/replay": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry-internal/feedback": "7.108.0",
+        "@sentry-internal/replay-canvas": "7.108.0",
+        "@sentry-internal/tracing": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/replay": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/bundler-plugin-core": {
@@ -22014,48 +22014,48 @@
       "optional": true
     },
     "@sentry/core": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
-      "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.108.0.tgz",
+      "integrity": "sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==",
       "requires": {
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/react": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.99.0.tgz",
-      "integrity": "sha512-RtHwgzMHJhzJfSQpVG0SDPQYMTGDX3Q37/YWI59S4ALMbSW4/F6n/eQAvGVYZKbh2UCSqgFuRWaXOYkSZT17wA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.108.0.tgz",
+      "integrity": "sha512-C60arh5/gtO42eMU9l34aWlKDLZUO+1j1goaEf/XRSwUcyJS9tbJrs+mT4nbKxUsEG714It2gRbfSEvh1eXmCg==",
       "requires": {
-        "@sentry/browser": "7.99.0",
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0",
+        "@sentry/browser": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0",
         "hoist-non-react-statics": "^3.3.2"
       }
     },
     "@sentry/replay": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.99.0.tgz",
-      "integrity": "sha512-gyN/I2WpQrLAZDT+rScB/0jnFL2knEVBo8U8/OVt8gNP20Pq8T/rDZKO/TG0cBfvULDUbJj2P4CJryn2p/O2rA==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.108.0.tgz",
+      "integrity": "sha512-jo8fDOzcZJclP1+4n9jUtVxTlBFT9hXwxhAMrhrt70FV/nfmCtYQMD3bzIj79nwbhUtFP6pN39JH1o7Xqt1hxQ==",
       "requires": {
-        "@sentry-internal/tracing": "7.99.0",
-        "@sentry/core": "7.99.0",
-        "@sentry/types": "7.99.0",
-        "@sentry/utils": "7.99.0"
+        "@sentry-internal/tracing": "7.108.0",
+        "@sentry/core": "7.108.0",
+        "@sentry/types": "7.108.0",
+        "@sentry/utils": "7.108.0"
       }
     },
     "@sentry/types": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
-      "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA=="
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.108.0.tgz",
+      "integrity": "sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g=="
     },
     "@sentry/utils": {
-      "version": "7.99.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
-      "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
+      "version": "7.108.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.108.0.tgz",
+      "integrity": "sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==",
       "requires": {
-        "@sentry/types": "7.99.0"
+        "@sentry/types": "7.108.0"
       }
     },
     "@sentry/webpack-plugin": {

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "~7.99.0",
+    "@sentry/react": "~7.108.0",
     "@testing-library/jest-dom": "~5.11.4",
     "@testing-library/react": "~11.1.0",
     "@testing-library/user-event": "~12.1.10",

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -115,6 +115,7 @@ Sentry.init({
         // This enables profiling of route transactions in react
         onStartRouteTransaction: Sentry.onProfilingStartRouteTransaction,
       },
+      enableInp: true,
     }),
     new Sentry.Replay({
       // Additional configuration goes in here


### PR DESCRIPTION
Updates sentry react to 7.108.0 and turn on the `enableInp` flag in the browser tracing integration.