### PR TITLE
switch dummy emails from gmail to example.com

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -268,7 +268,7 @@ class App extends Component {
         let a = array[Math.floor(Math.random() * array.length)];
         let b = array[Math.floor(Math.random() * array.length)];
         let c = array[Math.floor(Math.random() * array.length)];
-        email = a + b + c + '@gmail.com';
+        email = a + b + c + '@example.com';
       }
       scope.setUser({ email: email });
     });


### PR DESCRIPTION
I didn't test this since it's such a simple change, but what could go wrong, right? Right? 😅 

I know we're masking them in sentry, but there are still opportunities for this to be problematic. Better to just fix it at the source. Example 'problem' is this showing up:

<img width="1583" alt="Screenshot 2024-05-08 at 4 03 04 PM" src="https://github.com/sentry-demos/empower/assets/12092849/d3c7a97d-6f9f-442d-9837-c4f77b5af0b8">

Sometimes marketing or docs needs to take screenshots, so might as well just use example.com everywhere