### PR TITLE
Ensure codecov flags get uploaded upon merge to master branch

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -5,9 +5,9 @@ run-name: Deployment triggered by ${{ github.event_name }} / ${{ github.actor }}
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   schedule:
-    - cron:  '40 3 * * *' # every day at 8:40pm PDT / 5:40am GMT+2
+    - cron: "40 3 * * *" # every day at 8:40pm PDT / 5:40am GMT+2
     # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   workflow_dispatch:
 
@@ -20,93 +20,96 @@ jobs:
   default-job:
     if: github.repository_owner == 'sentry-demos' # don't run in forks
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     runs-on: ubuntu-22.04
-    
+
     steps:
       - run: |
           SENTRY_CRON='https://o87286.ingest.sentry.io/api/4505620224540672/cron/auto-deploy/21b95d7975af21218dd7c14f1e48e193/'
           curl "$SENTRY_CRON?status=in_progress"
           echo "SENTRY_CRON=$SENTRY_CRON" >> "$GITHUB_ENV"
-    
+
       - run: echo "Triggered by ${{ github.event_name }} event."
       - run: echo "Branch is ${{ github.ref }}"
-      
+
       - name: Check out this repository code
         uses: actions/checkout@v3
         with:
           path: empower
           fetch-depth: 0
-        
+
       - name: Check out `empower-config` to get env-config
         uses: actions/checkout@v3
         with:
           repository: sentry-demos/empower-config
           path: empower-config
           token: ${{ secrets.KOSTY_PERSONAL_ACCESS_TOKEN_FOR_SYNC_DEPLOY_FORK }}
-        
+
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
-          
+          node-version: "18"
+
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@v1.3.0
         with:
           version: 2.17.4
           token: ${{ SECRETS.SENTRY_AUTH_TOKEN }} # from GitHub secrets
-          
+
       - name: Get commit SHA that was last successfully deployed
         uses: nrwl/nx-set-shas@v3.0.1
         with:
           main-branch-name: master
           error-on-no-successful-workflow: false
           working-directory: ./empower
-      
+
       # Test previous step worked
       - run: |
           echo "BASE: ${{ env.NX_BASE }}"
           echo "HEAD: ${{ env.NX_HEAD }}"
-          
-      - name: Run tests
+
+      - name: Run React tests
         run: |
           npm install
           npm test -- --coverage
         working-directory: ./empower/react
-        
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: frontend
+
       - name: Run Python Tests
         run: |
           pip install -U pytest
           pip install pytest-codecov
           pytest --cov=. --cov-report=xml
         working-directory: ./empower/flask/src
-        
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v3
         with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-          
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: api
+
       - name: Get GCP_ env variables from empower-config/.gcloudrc
         run: |
           source empower-config/.gcloudrc 
           echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$GCP_WORKLOAD_IDENTITY_PROVIDER" >> $GITHUB_OUTPUT
-          echo "GCP_SERVICE_ACCOUNT=$GCP_SERVICE_ACCOUNT" >> $GITHUB_OUTPUT 
+          echo "GCP_SERVICE_ACCOUNT=$GCP_SERVICE_ACCOUNT" >> $GITHUB_OUTPUT
         id: gcloudrc
-        
-      - id: 'auth'
-        name: 'Authenticate Google Cloud'
-        uses: 'google-github-actions/auth@v0'
+
+      - id: "auth"
+        name: "Authenticate Google Cloud"
+        uses: "google-github-actions/auth@v0"
         with:
           workload_identity_provider: ${{ steps.gcloudrc.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ steps.gcloudrc.outputs.GCP_SERVICE_ACCOUNT }}
 
-      - name: 'Set up Google Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
-        
+      - name: "Set up Google Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v0"
+
       - name: Get env-config/production.env from empower-config
         run: cp empower-config/production.env empower/env-config/
-        
+
       - name: Deploy to production
         run: |
           CHANGED_PROJECTS=$(./bin/projects_changed_bw_commits.sh "${{ env.NX_BASE }}" "${{ env.NX_HEAD }}")
@@ -119,14 +122,13 @@ jobs:
             echo "No deployable projects have been changed since last successful deployment. New calendar release is not due either. Nothing to do."
           fi
         working-directory: ./empower
-          
+
       - run: echo "Job status is ${{ job.status }}."
-      
+
       - name: Report success to Cron monitor (demo/empower-github-workflows)
         run: curl "${{ env.SENTRY_CRON }}?status=ok"
-      
+
       # 'if: always()' ensures step is run even if earlier step failed
       - name: Report error to Cron monitor (demo/empower-github-workflows)
         if: always() && job.status == 'failure'
         run: curl "${{ env.SENTRY_CRON }}?status=error"
-


### PR DESCRIPTION
- Sorry in advance about formatting diff 😞 [Real changes are these lines](https://github.com/sentry-demos/empower/pull/512/files#diff-39749da973a6d7b52c07bb6bc3a69ed00b12326959c832a3bc3b7b35eb12328cR72-R92)
- Trying to get rid of `?` on coverage delta [here](https://github.com/sentry-demos/empower/pull/463#issuecomment-2091930560)

![Screenshot 2024-05-07 at 1 01 59 PM](https://github.com/sentry-demos/empower/assets/12092849/5168f59b-b337-4b93-a5eb-6533ded7c9f0)

- Codecov team suggests that it's due to difference between how our yml files upload codecov reports: `auto-deploy.yml` uploads reports with no flags, but `run_codecov_on_pull_request.yml` uploads reports with flags `api` and `frontend`.
- This PR would adjust `auto-deploy.yml` to set those flags as well.

![Screenshot 2024-05-10 at 3 39 51 PM](https://github.com/sentry-demos/empower/assets/12092849/af6b2677-cd81-4a53-a243-9b24a6a6b600)
