### PR TITLE
Launchdarkly recommendations for better demo data

### DIFF
--- a/react/src/components/About.jsx
+++ b/react/src/components/About.jsx
@@ -82,6 +82,7 @@ function About({ backend }) {
       } else {
         console.log(`LaunchDarkly flag ${ldFlag} is not enabled...`);
       }
+      ldClient.flush()
     } else {
       console.log(`Launchdarkly client is not on the react context`)
   }, []);

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -299,11 +299,6 @@ const App = () => {
     "name": queryParams.get('se'),
   };
 
-  Sentry.setContext('launchdarklyContext', {
-    "kind": lDKind,
-    "key": email,
-  });
-
   useEffect(() => {
     const initializeLDClient = async () => {
       const client = LDClient.initialize(process.env.REACT_APP_LAUNCHDARKLY_ENVKEY, lDUser); // see console: [LaunchDarkly] LaunchDarkly client initialized


### PR DESCRIPTION
This makes two changes that should produce more conclusive data in LaunchDarkly.

1. Call `ldClient.flush` proactively. We flush events periodically, so if you're frequently refreshing the page to power your demo, we might not reliably flush events to LaunchDarkly. By calling `flush` after the variation call, the event should be emitted more reliably.
2. Move the setting of `launchdarklyContext` on the Sentry context to be close to the flag evaluation. This should help us avoid the scenario you we running into where other errors were creating noise on the LaunchDarkly side. The fix here is to only set the data that allows us to join your error to LaunchDarkly data when you're going to interact with the LaunchDarkly flag.