### PR TITLE
Attach context on scope

### DIFF
--- a/react/src/components/About.jsx
+++ b/react/src/components/About.jsx
@@ -59,24 +59,23 @@ function About({ backend }) {
     if(lDContext.lDClient) {
       const ldClient = lDContext.lDClient;
       const ldContext = ldClient.getContext();
-      Sentry.setContext('launchdarklyContext', {
-        "kind": ldContext.kind,
-        "key": ldContext.key,
-      });
-
       // throw error if LaunchDarkly Feature Flag is enabled
       const ldFlag = 'my-sentry-integration-feature';
       if (ldClient.variation(ldFlag, false)) {
         console.log(`LaunchDarkly flag ${ldFlag} is enabled!`);
-        Sentry.configureScope(function (scope) {
-          Sentry.setContext('response', request1);
+        Sentry.withScope(function (scope) {
+          scope.setContext('response', request1);
+          scope.setContext('launchdarklyContext', {
+            "kind": ldContext.kind,
+            "key": ldContext.key,
+          });
+          Sentry.captureException(
+            new Error(
+              request1.status + ' - Error from Feature Flag (LaunchDarkly)'
+            )
+          );
+          console.log(`Generated error specific to LaunchDarkly feature flag`);
         });
-        Sentry.captureException(
-          new Error(
-            request1.status + ' - Error from Feature Flag (LaunchDarkly)'
-          )
-        );
-        console.log(`Generated error specific to LaunchDarkly feature flag`);
       } else {
         console.log(`LaunchDarkly flag ${ldFlag} is not enabled...`);
       }


### PR DESCRIPTION
I misunderstood how sentry contexts work: didn't realize they were global. This changes how we attach the LaunchDarkly context to be in its own scope after the feature flag evaluation. This will stop errors that aren't related to the flag from being associated with the flag. I believe that issue (other errors getting associated with the context) is the issue you're seeing with the error rates. I was able to test this and observe that the LaunchDarkly context is only being attached to the errors generated when the flag was evaluated.

This isn't an issue customers will need to worry about. Customer applications won't have such a high rate of errors, so that noise won't be present in their apps.

One other thing to note. Before testing this, be sure to stop your measured rollout and start a new one in LaunchDarkly. The data is cumulative, so adding new data to a running rollout might not have the intended effect.