### PR TITLE
Bump Python SDK version

### DIFF
--- a/crons-python/requirements.txt
+++ b/crons-python/requirements.txt
@@ -1,2 +1,2 @@
-sentry-sdk==1.23.0
+sentry-sdk==2.4.0
 python-dotenv==1.0.0

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -8,5 +8,5 @@ pg8000==1.16.6
 psycopg2-binary==2.9.9
 python-dotenv==0.12.0
 pytz==2020.4
-sentry-sdk==1.40.0
+sentry-sdk==2.4.0
 sqlalchemy==1.4.49

--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -10,7 +10,6 @@ import dotenv
 from .db import get_products, get_products_join, get_inventory
 from .utils import parseHeaders, get_iterator
 import sentry_sdk
-from sentry_sdk import metrics
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 

--- a/tda/requirements.txt
+++ b/tda/requirements.txt
@@ -6,4 +6,4 @@ selenium==4.14.0
 Appium-Python-Client==2.11.1
 PyYAML==6.0.1
 requests==2.28.2
-sentry-sdk==1.32.0
+sentry-sdk==2.4.0


### PR DESCRIPTION
- Bumped Python SDK to 2.4.0. There have been no breaking changes in the API that we're using in Empower, so no code changes necessary.
- Removed one unused import.