### PR TITLE
Selectors reflect app v3.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ env-config/*
 !env-config/example.env
 
 **/local.env
-tests/env
+tda/env
 
 # .NET
 aspnetcore/bin

--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -453,7 +453,7 @@ def ios_react_native_sim_driver(request, selenium_endpoint, se_prefix):
             'appium:platformVersion': '14.5',
 
             'sauce:options': {
-                'appiumVersion': '1.21.0',
+                'appiumVersion': '2.0.0',
                 'build': 'RDC-iOS-Python-Best-Practice',
                 'name': request.node.name,
             },

--- a/tda/mobile_native/android_react_native/test_captureexception_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_captureexception_react_native_android.py
@@ -5,7 +5,7 @@ def test_captureexception_react_native_android(android_react_native_emu_driver):
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'LIST APP').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
 
         # trigger exception
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Capture Exception"]')

--- a/tda/mobile_native/android_react_native/test_capturemessage_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_capturemessage_react_native_android.py
@@ -5,7 +5,7 @@ def test_capturemessage_react_native_android(android_react_native_emu_driver):
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'LIST APP').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
 
         # trigger message
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Capture Message"]')

--- a/tda/mobile_native/android_react_native/test_checkout_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_checkout_react_native_android.py
@@ -4,27 +4,29 @@ from appium.webdriver.common.appiumby import AppiumBy
 def test_checkout_react_native_android(android_react_native_emu_driver):
 
     try:
-        add_to_cart_btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '(//android.widget.TextView[@text="Add to Cart"])[1]')
+        add_to_cart_btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '(//android.view.ViewGroup[@content-desc="Add to cart"])[1]')
         add_to_cart_btn.click()
         add_to_cart_btn.click()
         add_to_cart_btn.click()
 
-        # 'view cart' button
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'CART').click()
+        # Click cart at bottom
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[2]').click()
 
         # checkout button
         android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'CHECKOUT').click()
 
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.EditText[@text="email"]').click
+        if android_react_native_emu_driver.is_keyboard_shown():
+            android_react_native_emu_driver.hide_keyboard()
+
         # Appium on android can't find the 'place your order' button
         # unless we scroll down to it
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '(//android.widget.EditText)[1]')
-
-        top_of_screen_element = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '(//android.widget.EditText)[1]')
-        bottom_of_screen_element = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '(//android.widget.EditText)[7]')
+        top_of_screen_element = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.EditText[@text="email"]')
+        bottom_of_screen_element = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.EditText[@text="country/region"]')
         android_react_native_emu_driver.scroll(bottom_of_screen_element, top_of_screen_element)
 
         # Place order button
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Place your order"]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Place your order').click()
 
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/tda/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -5,7 +5,7 @@ def test_homescreen_react_native_android(android_react_native_emu_driver, random
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'LIST APP').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
 
         # Handled Exceptions - This clicks the Handled Exception' button in the app
         # This error type does not increment the Crash Count for the release,

--- a/tda/mobile_native/android_react_native/test_nativecrash_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_nativecrash_react_native_android.py
@@ -5,7 +5,7 @@ def test_nativecrash_react_native_android(android_react_native_emu_driver):
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'LIST APP').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
 
         # trigger crash
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Native Crash"]')

--- a/tda/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -5,7 +5,7 @@ def test_uncaughtthrownerror_react_native_android(android_react_native_emu_drive
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'LIST APP').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
 
         # trigger error
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Uncaught Thrown Error"]')

--- a/tda/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -5,7 +5,7 @@ def test_unhandledpromiserejection_react_native_android(android_react_native_emu
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'LIST APP').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
 
         # trigger error
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Unhandled Promise Rejection"]')

--- a/tda/mobile_native/ios_react_native/test_captureexception_react_native_ios.py
+++ b/tda/mobile_native/ios_react_native/test_captureexception_react_native_ios.py
@@ -5,8 +5,8 @@ def test_captureexception_react_native_ios(ios_react_native_sim_driver):
 
     try:
         # click on list app
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="List App"]').click()
-        
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Debug, tab, 3 of 3').click()
+
         # click 'capture exception' button
         btn = ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Capture Exception")
         btn.click()

--- a/tda/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
+++ b/tda/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
@@ -5,8 +5,8 @@ def test_capturemessage_react_native_ios(ios_react_native_sim_driver):
 
     try:
         # click on list app
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="List App"]').click()
-        
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Debug, tab, 3 of 3').click()
+
         # click 'capture message' button
         btn = ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Capture Message")
         btn.click()

--- a/tda/mobile_native/ios_react_native/test_checkout_react_native_ios.py
+++ b/tda/mobile_native/ios_react_native/test_checkout_react_native_ios.py
@@ -1,19 +1,25 @@
 import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
+import time
 
 def test_checkout_react_native_ios(ios_react_native_sim_driver):
 
     try:
-        cart_btn = ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '(//XCUIElementTypeOther[@name="Add to Cart"])[1]')
+        cart_btn = ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '(//XCUIElementTypeOther[@name="Add to cart"])[2]')
         cart_btn.click()
         cart_btn.click()
         cart_btn.click()
         cart_btn.click()
 
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="Cart"]').click()
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="Checkout"]').click()
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Cart, tab, 2 of 3').click()
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Checkout').click()
 
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '(//XCUIElementTypeOther[@name="email"])[3]/XCUIElementTypeTextField').click()
+        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeTextField[@value="email"]').click()
+
+        # click 'return' if keyboard is up, as its being shown intermittently
+        if ios_react_native_sim_driver.is_keyboard_shown():
+            ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Return').click()
+
         ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '(//XCUIElementTypeOther[@name="Place your order"])[2]').click()
 
     except Exception as err:

--- a/tda/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
+++ b/tda/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
@@ -5,13 +5,13 @@ def test_nativecrash_react_native_ios(ios_react_native_sim_driver):
 
     try:
         # click on list app
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="List App"]').click()
-        
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Debug, tab, 3 of 3').click()
+
         # click 'native crash' button
         btn = ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Native Crash")
         btn.click()
         # launch app again or the error does not get sent to Sentry
         ios_react_native_sim_driver.launch_app()
-    
+
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/tda/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
+++ b/tda/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
@@ -2,16 +2,16 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_uncaughtthrownerror_react_native_ios(ios_react_native_sim_driver):
-    
+
     try:
         # click on list app
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="List App"]').click()
-        
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Debug, tab, 3 of 3').click()
+
         # click uncaught-error button
         btn = ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Uncaught Thrown Error")
         btn.click()
         # launch app again or the error does not get sent to Sentry
         ios_react_native_sim_driver.launch_app()
-    
+
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/tda/mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
+++ b/tda/mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
@@ -5,11 +5,11 @@ def test_unhandledpromiserejection_react_native_ios(ios_react_native_sim_driver)
 
     try:
         # click on list app
-        ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="List App"]').click()
-        
+        ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Debug, tab, 3 of 3').click()
+
         # click unhandled promise rejection button
         btn = ios_react_native_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Unhandled Promise Rejection")
         btn.click()
-    
+
     except Exception as err:
         sentry_sdk.capture_exception(err)


### PR DESCRIPTION
For ios, we needed to use more recent version of appium to hide_keyboard since it comes up intermittently. For Android, now clicking on first textbook to populate textfields