### PR TITLE
chore(react): Bump to latest sentry react sdk

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "application-monitoring",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "~8.15.0",
+        "@sentry/react": "~8.20.0",
         "@testing-library/jest-dom": "~5.11.4",
         "@testing-library/react": "~11.1.0",
         "@testing-library/user-event": "~12.1.10",
@@ -4094,54 +4094,54 @@
       "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg=="
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.15.0.tgz",
-      "integrity": "sha512-DquySUQRnmMyRbfHH9t/JDwPMsVaCOCzV/6XmMb7s4FDYTWSCSpumJEYfiyJCuI9NeebPHZWF7LZCHH4glSAJQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.20.0.tgz",
+      "integrity": "sha512-GGYNiELnT4ByidHyS4/M8UF8Oxagm5R13QyTncQGq8nZcQhcFZ9mdxLnf1/R4+j44Fph2Cgzafe8jGP/AMA9zw==",
       "dependencies": {
-        "@sentry/core": "8.15.0",
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0"
+        "@sentry/core": "8.20.0",
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.15.0.tgz",
-      "integrity": "sha512-W6XiLpw7fL1A0KaHxIH45nbC2M8uagrMoBnMZ1NcqE4AoSe7VtoDqPsLvQ7MgMXwsBYiPu2AItRnKoGFS/dUBA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.20.0.tgz",
+      "integrity": "sha512-mFvAoVpVShkDB2AgEr/dE96NSTPKI/lGMBznZMg7ZEcwZhLfH7HvLYCadIskRfzqFTLOUpbm9ciIO4SyR/4bDA==",
       "dependencies": {
-        "@sentry/core": "8.15.0",
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0"
+        "@sentry/core": "8.20.0",
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.15.0.tgz",
-      "integrity": "sha512-d4cA8pjr0CGHkTe8ulqMROYCX3bMHBAi/7DJBr11i4MdNCUl+/pndA9C5TiFv0sFzk/hDZQZS3J+MfGp56ZQHw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.20.0.tgz",
+      "integrity": "sha512-sCiI7SOAHq5XsxkixtoMofeSyKd/hVgDV+4145f6nN9m7nLzig4PBQwh2SgK2piJ2mfaXfqcdzA1pShPYldaJA==",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.15.0",
-        "@sentry/core": "8.15.0",
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0"
+        "@sentry-internal/browser-utils": "8.20.0",
+        "@sentry/core": "8.20.0",
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.15.0.tgz",
-      "integrity": "sha512-gfezIuvf94wY748l5wSy4pRm+45GjiBm0Q/KLnXROLZKmbI7MTJrdQXA2Oxut848iISTQo4/LimecFnBDiaGtw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.20.0.tgz",
+      "integrity": "sha512-LXV/pMH9KMw6CtImenMsiBkYIFIc97pDJ/rC7mVImKIROQ45fxGp/JBXM4Id0GENyA2+SySMWVQCAAapSfHZTw==",
       "dependencies": {
-        "@sentry-internal/replay": "8.15.0",
-        "@sentry/core": "8.15.0",
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0"
+        "@sentry-internal/replay": "8.20.0",
+        "@sentry/core": "8.20.0",
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -4157,17 +4157,17 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.15.0.tgz",
-      "integrity": "sha512-Tx4eFgAqa8tedg30+Cgr7qFocWHise8p3jb/RSNs+TCEBXLVtQidHHVZMO71FWUAC86D7woo5hMKTt+UmB8pgg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.20.0.tgz",
+      "integrity": "sha512-JDZbCreY44/fHYN28QzsAwEHXa2rc1hzM6GE4RSlXCdAhNfrjVxyYDxhw/50pVEHZg1WXxf7ZmERjocV5VJHsw==",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.15.0",
-        "@sentry-internal/feedback": "8.15.0",
-        "@sentry-internal/replay": "8.15.0",
-        "@sentry-internal/replay-canvas": "8.15.0",
-        "@sentry/core": "8.15.0",
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0"
+        "@sentry-internal/browser-utils": "8.20.0",
+        "@sentry-internal/feedback": "8.20.0",
+        "@sentry-internal/replay": "8.20.0",
+        "@sentry-internal/replay-canvas": "8.20.0",
+        "@sentry/core": "8.20.0",
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -4409,26 +4409,26 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.15.0.tgz",
-      "integrity": "sha512-RjuEq/34VjNmxlfzq+485jG63/Vst90svQapLwVgBZWgM8jxrLyCRXHU0wfBc7/1IhV/T9GYAplrJQAkG4J9Ow==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.20.0.tgz",
+      "integrity": "sha512-R81snuw+67VT4aCxr6ShST/s0Y6FlwN2YczhDwaGyzumn5rlvA6A4JtQDeExduNoDDyv4T3LrmW8wlYZn3CJJw==",
       "dependencies": {
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0"
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.15.0.tgz",
-      "integrity": "sha512-mRkWZ3gVkgT5VrRVHfOlritsxNM0XOOkOqKP2WXiHCRCGKns7hwGcEt5Y9AKFITIKL9ADtmE22tjv69V5fYwqQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.20.0.tgz",
+      "integrity": "sha512-vqA0o9ysdfA24/ADhsJwsmCNdUWRu2ycmVN1Sr76v+ZggyOCFzE7XD13kbqk1G3jPb8nptNu/6Zwpcy5pP4mtw==",
       "dependencies": {
-        "@sentry/browser": "8.15.0",
-        "@sentry/core": "8.15.0",
-        "@sentry/types": "8.15.0",
-        "@sentry/utils": "8.15.0",
+        "@sentry/browser": "8.20.0",
+        "@sentry/core": "8.20.0",
+        "@sentry/types": "8.20.0",
+        "@sentry/utils": "8.20.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -4439,19 +4439,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.15.0.tgz",
-      "integrity": "sha512-AZc9nSHKuNH8P/7ihmq5fbZBiQ7Gr35kJq9Tad9eVuOgL8D+2b6Vqu/61ljVVlMFI0tBGFsSkWJ/00PfBcVKWg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.15.0.tgz",
-      "integrity": "sha512-1ISmyYFuRHJbGun0gUYscyz1aP6RfILUldNAUwQwF0Ycu8YOi4n8uwJRN0aov6cCi41tnZWOMBagSeLxbJiJgQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.20.0.tgz",
+      "integrity": "sha512-+1I5H8dojURiEUGPliDwheQk8dhjp8uV1sMccR/W/zjFrt4wZyPs+Ttp/V7gzm9LDJoNek9tmELert/jQqWTgg==",
       "dependencies": {
-        "@sentry/types": "8.15.0"
+        "@sentry/types": "8.20.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -20179,16 +20179,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "~8.15.0",
+    "@sentry/react": "~8.20.0",
     "@testing-library/jest-dom": "~5.11.4",
     "@testing-library/react": "~11.1.0",
     "@testing-library/user-event": "~12.1.10",


### PR DESCRIPTION
I've noticed a discussion about pageload transactions missing since the bump to the v8 SDK. This seems to happen with replay integrations + chrome and has been fixed with https://github.com/getsentry/sentry-javascript/pull/12933.