### PR TITLE
[express] upgrade Node 14.x -> 18.x (GCP dropped support)

### DIFF
--- a/express/app.yaml.template
+++ b/express/app.yaml.template
@@ -1,2 +1,2 @@
 service: <SERVICE>
-runtime: nodejs14
+runtime: nodejs18

--- a/express/package.json
+++ b/express/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
   },
   "engines": {
-    "node": "14.x.x"
+    "node": "18.x.x"
   },
   "author": "Google Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Testing
✅ (loads something) https://staging-application-monitoring-node-dot-sales-engineering-sf.appspot.com/products
✅ (standard demo flow) https://staging-application-monitoring-react-dot-sales-engineering-sf.appspot.com/?se=express-node-upgrade-14-to-18&back

# Duration - AFTER
Still waiting for some txns to arrive delayed by INC but looks within the same range
https://demo.sentry.io/discover/homepage/?display=top5&field=transaction&field=p50%28transaction.duration%29&field=min%28transaction.duration%29&field=max%28transaction.duration%29&field=count%28%29&id=21645&name=&project=4504330844635136&query=event.type%3Atransaction+transaction%3A%22GET+%2Fproducts%22&sort=-transaction&statsPeriod=24h&topEvents=5
# Duration - BEFORE
<img width="679" alt="Screenshot 2024-08-19 at 12 38 39 PM" src="https://github.com/user-attachments/assets/d7f70c1f-7b7f-4e53-9ee5-7f255977a85c">
end=express