### PR TITLE
put flags and components next to each other in codecov PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,7 +24,7 @@ github_checks:
   annotations: true
 
 comment:
-  layout: "newheader, diff, flags, files, components"
+  layout: "newheader, diff, flags, components, files"
   require_changes: false # false :: posts comment regardless of whether coverage changes
   require_base: false # [false :: doesn't need a base report to post]
   require_head: true # [true :: must have a head report to post]


### PR DESCRIPTION
with these changes, we should see components -> flags -> files in the PR comment. The PR comment in this PR doesn't show files because no files covered by tests were changed and no new files were added.

## old way (components -> files -> flags)

![Screenshot 2024-08-23 at 10 15 54 AM](https://github.com/user-attachments/assets/1b8307b4-53c3-4459-a610-159ef24fee24)

