### PR TITLE
fix replay .sentry-unblock after v7->v8 everything is ******

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -95,6 +95,7 @@ Sentry.init({
       blockAllMedia: false,
       // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details
       networkDetailAllowUrls: ['/checkout', '/products'],
+      unmask: [".sentry-unmask"],
     }),
   ],
   beforeSend(event, hint) {


### PR DESCRIPTION
https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/#change-of-replay-default-options-unblock-and-unmask

Let's actually follow migration docs next time 😄

BEFORE
<img width="546" alt="Screenshot 2024-08-26 at 5 40 07 PM" src="https://github.com/user-attachments/assets/c197ed9f-4c83-41ab-8234-55defd0b3894">

AFTER
<img width="542" alt="Screenshot 2024-08-26 at 5 40 35 PM" src="https://github.com/user-attachments/assets/b9df8ed1-d71f-477b-b8f8-ca483de1896d">
