### PR TITLE
Exclude Next from auto-deploy since it has it's own Vercel automation

### DIFF
--- a/auto-deploy.exclude
+++ b/auto-deploy.exclude
@@ -8,3 +8,5 @@ postgres
 crons-python
 ruby-on-rails 
 # ^ see https://github.com/sentry-demos/empower/issues/439
+next
+# ^ uses Vercel automation


### PR DESCRIPTION
currently breaking our pipeline https://github.com/sentry-demos/empower/actions/runs/11432793019/job/31803804101

I wonder if Vercel's bot will now post in all commits in this repo (this one modified file in root directory, not next).. maybe there's a way to limit it to changes in `next` directory only? I'd say it's not a big deal except that it adds noise to codecov demo. @ndmanvar what do you think?