### PR TITLE
Fix sleep time conditional

### DIFF
--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -281,7 +281,7 @@ def get_api_request(key, delay):
 
               time_delta = time.time() - start_time
               sleep_time = delay - time_delta
-              if time_delta > 0:
+              if sleep_time > 0:
                 time.sleep(sleep_time)
 
               # For demo show we want to show cache misses so only save 1 / 100


### PR DESCRIPTION
- Conditional for sleep time should check sleep_time not time_delta

Example [error](https://demo.sentry.io/issues/6131235906/events/3235cb0fb30d45da956bc065ad6f562b/?project=5808655)