### PR TITLE
Override default flask_caching key prefix

### DIFF
--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -111,7 +111,8 @@ cache_config = {
     "CACHE_TYPE": "RedisCache",  # Flask-Caching related configs
     "CACHE_DEFAULT_TIMEOUT": 300,
     "CACHE_REDIS_HOST": redis_host,
-    "CACHE_REDIS_PORT": redis_port
+    "CACHE_REDIS_PORT": redis_port,
+    "CACHE_KEY_PREFIX": None
 }
 
 app.config.from_mapping(cache_config)


### PR DESCRIPTION
 - flask_cache_ was being added as a default key prefix which interfering with it showing up in the Sentry UI