### PR TITLE
[tda] Critical Experiences - switch to 24 hour cycle

### DIFF
--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -260,8 +260,12 @@ def cexp(random):
         #    return 3 + now.minute // 30
 
         # change every hour, except for segment #4 that's 2 hours long (cycle = 6 hours)
-        mod5 = now.hour % 6 
-        return 4 if mod5 == 5 else mod5
+        #mod5 = now.hour % 6 
+        #return 4 if mod5 == 5 else mod5
+        
+        # change every 4 hours, except for segment #4 that's 8 hours long (cycle = 24 hours)
+        d4 = now.hour // 4
+        return 4 if d4 == 5 else d4
 
     # array length must match number of possible time segments
     probabilities = {       # segments    0    1    2    3    4 


### PR DESCRIPTION
This should make graphs a little smoother
If this is not enough we can switch to 6-day cycle (or 14/30-day to match what SE will often have as time interval during demos)
Eventually we want this to be on a 6 week cycle to match releases (can now be overlayed in dashboards)
