### PR TITLE
[react] fix Products.test.js failing after PR 667; rename codecov.yml

### DIFF
--- a/.github/workflows/run_codecov_on_pull_request.yml
+++ b/.github/workflows/run_codecov_on_pull_request.yml
@@ -1,4 +1,4 @@
-name: codecov.yml
+name: run_codecov_on_pull_request.yml
 # Run Codecov on PR open or change
 on: 
   push:

--- a/react/src/tests/Products.test.js
+++ b/react/src/tests/Products.test.js
@@ -12,6 +12,7 @@ jest.mock('@sentry/react', () => ({
   withScope: jest.fn((fn) => fn({ _tags: { se: 'mocked_se' } })),
   captureException: jest.fn(),
   setContext: jest.fn(),
+  startSpan: jest.fn(),
   withProfiler: (Component) => Component,
 }));
 


### PR DESCRIPTION
<img width="786" alt="Screenshot 2025-01-29 at 2 03 29 PM" src="https://github.com/user-attachments/assets/98db34aa-77e8-4b4a-9544-4752b00c5046" />

although I think we should make `npm test --coverage` pass regardless if tests succeed or fail