### PR TITLE
[critexp] new segment schedule and probabilities

### DIFF
--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -264,22 +264,26 @@ def cexp(random):
         #return 4 if mod5 == 5 else mod5
         
         # change every 4 hours, except for segment #4 that's 8 hours long (cycle = 24 hours)
-        d4 = now.hour // 4
-        return 4 if d4 == 5 else d4
+        #d4 = now.hour // 4
+        #return 4 if d4 == 5 else d4
+
+        # 5 - 1 - 5 - 1 - 5 - 1 - 5 - 1
+        return (now.hour // 6) * 2 + (0 if now.hour % 6 < 5 else 1)
 
     # array length must match number of possible time segments
-    probabilities = {       # segments    0    1    2    3    4 
-        CExp.STANDARD_CHECKOUT_FAIL:    [1.0, 0.0, 0.0, 0.0, 0.0],
-        CExp.PRODUCTS_EXTREMELY_SLOW:   [0.0, 1.0, 0.0, 0.0, 0.0],
-        CExp.PRODUCTS_BE_ERROR:         [0.0, 0.0, 1.0, 0.0, 0.0],
-        CExp.ADD_TO_CART_JS_ERROR:      [0.0, 0.0, 0.0, 1.0, 0.0],
-        CExp.CHECKOUT_SUCCESS:          [0.0, 0.0, 0.0, 0.0, 1.0],
+    probabilities = {       # segments    0    1    2    3    4    5    6    7   
+        CExp.CHECKOUT_SUCCESS:          [1.0, 0.7, 1.0, 0.7, 1.0, 0.7, 1.0, 0.7 ],
+        CExp.STANDARD_CHECKOUT_FAIL:    [0,   0.3,  0,   0,   0,   0,   0,   0  ],
+        CExp.PRODUCTS_EXTREMELY_SLOW:   [0,    0,   0,  0.3,  0,   0,   0,   0  ],
+        CExp.PRODUCTS_BE_ERROR:         [0,    0,   0,   0,   0,  0.3,  0,   0  ],
+        CExp.ADD_TO_CART_JS_ERROR:      [0,    0,   0,   0,   0,   0,   0,  0.3 ],
     }
     
     def random_cexp():
+        segment = time_segment()
         return random.choices(
             list(probabilities.keys()),
-            weights=list(probabilities.values())[time_segment()],
+            weights=list([row[segment] for row in probabilities.values()]),
             k=1)[0]
 
     return random_cexp


### PR DESCRIPTION
1)
- smaller segments of error/slow
- no back-to-back segments of error/slow, “normal” segments in between
- same 24h total cycle
- 5 hours success, then 1 hour failure (one of 4 possible), then another 5 hours success, etc.
`-----_-----_-----_-----_`

2) when failing, don't fail 100% of the time, just 30% of the time (to be more realistic)

# Testing
```
RUN_ID=critexp-better-schedule python3 -m pytest -s -n 3 desktop_web/test_checkout.py
======================================================================================= test session starts =======================================================================================
platform darwin -- Python 3.13.1, pytest-7.4.2, pluggy-1.5.0
rootdir: /Users/kosty/home/emp3/tda
plugins: forked-1.4.0, xdist-3.1.0
gw0 [4] / gw1 [4] / gw2 [4]
....
================================================================================== 4 passed in 114.63s (0:01:54) ==================================================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-critexp_better_schedule%2A+%21project%3Aempower-tda&start=2025-03-07T23%3A27%3A50&end=2025-03-07T23%3A29%3A46
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-03-07T23%3A29%3A46&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-critexp_better_schedule%2A&queryDataset=error-events&sort=-timestamp&start=2025-03-07T23%3A27%3A50&yAxis=count%28%29A
```