### PR TITLE
[ruby] fix DSN missing because .env was ignored by gcloud deploy

### DIFF
--- a/ruby/build.sh
+++ b/ruby/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 bundle install
+cp .env gloud-ignore-workaround.env

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -1,7 +1,7 @@
 require 'sentry-ruby'
 require 'dotenv'
 
-Dotenv.load
+Dotenv.load('gloud-ignore-workaround.env')
 
 Sentry.init do |config|
   config.dsn = ENV['RUBY_DSN']


### PR DESCRIPTION
# Testing
`./deploy.sh --env=production ruby`
https://demo.sentry.io/stats/?dataCategory=spans&project=4508972558516224&statsPeriod=1h