### PR TITLE
[platform, flask] fix deploy.sh exit code by not killing celery

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -106,8 +106,6 @@ function cleanup {
   if [ "$generated_envs" != "" ]; then
     rm -f $generated_envs # bash only (passed as separate args)
   fi
-  # terminate the celery workers
-  pkill -f "celery worker"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
when no celery process present deploy.sh would return -1 which was confusing and would break CI

# Testing
`./deploy.sh --env=local flask`
http://127.0.0.1:8181/products
Cmd+C
`./deploy.sh --env=local flask`
http://127.0.0.1:8181/products
Cmd+C
`./deploy.sh --env=local flask`
http://127.0.0.1:8181/products
Cmd+C