### PR TITLE
[flask] Fix error rate by removing custom instrumentation

### DIFF
--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -124,11 +124,9 @@ redis_client = redis.Redis(host=redis_host, port=redis_port, decode_responses=Tr
 @app.route('/enqueue', methods=['POST'])
 def enqueue():
     body = json.loads(request.data)
-    print(body['email'])
     email = body['email']
-    with sentry_sdk.start_transaction(name="src.api.enqueueEmail"):
-        r = sendEmail.apply_async(args=[email], queue='celery-new-subscriptions')
-        print(r.task_id)
+    r = sendEmail.apply_async(args=[email], queue='celery-new-subscriptions')
+    print(f"task id: {r.task_id} for email: {email}")
     return jsonify({"status": "success"}), 200
 
 

--- a/flask/src/queues/email_subscribe.py
+++ b/flask/src/queues/email_subscribe.py
@@ -31,6 +31,7 @@ def init_sentry(**_kwargs):
         environment=ENVIRONMENT,
         traces_sample_rate=1.0,
         profiles_sample_rate=1.0,
+        debug=True,
     )
 
 if __name__ == '__main__':

--- a/flask/src/queues/tasks.py
+++ b/flask/src/queues/tasks.py
@@ -13,5 +13,4 @@ def sendEmail(self, email):
     print("Sending email to: " + email)
     return x
   except Exception as e:
-      with sentry_sdk.start_transaction(name=f"{self.__qualname__} (retry)"):
-        raise self.retry(exc=e, countdown=10, max_retries=5)
+      raise self.retry(exc=e, countdown=10, max_retries=5)


### PR DESCRIPTION
- Custom instrumentation was creating a transaction within a transaction, resulting in the sdk not picking up the real error rate
- Remove custom instrumentation means the sdk will infer the name
-- retry now has same transaction name as consumer
-- main produce is named after function endpoint "enqueue"


**Before**
![image](https://github.com/user-attachments/assets/5a326e3e-99f1-4b6b-b9d9-e0995a1fe433)

**After**
![image](https://github.com/user-attachments/assets/db912f01-7ec0-4132-bd35-298c1c70b6cc)
