### PR TITLE
Catch Inventory Error for CEXP

### DIFF
--- a/react/src/components/ProductCard.jsx
+++ b/react/src/components/ProductCard.jsx
@@ -16,7 +16,11 @@ function ProductCard(props) {
   const stars = props.stars;
 
   function validate_inventory(product) {
-    return product && inventory.includes(product.id)
+    try {
+      return product && inventory.includes(product.id)
+    } catch (error) {
+      throw new Error("Error validating inventory");
+    }
   }
 
   return (


### PR DESCRIPTION
Before 
![Screenshot 2025-03-25 at 1 56 24 PM](https://github.com/user-attachments/assets/e08b1e91-40ca-4e42-a510-b168d9189a42)

After
![Screenshot 2025-03-25 at 1 56 52 PM](https://github.com/user-attachments/assets/9bd79c6d-8419-4201-8e31-ab066c74b439)

The fix to this is quite simple. But I am having some issues getting source maps working to show the working error's stack trace that are not related to the changes I am making here :(