### PR TITLE
[critexp] Releases that line up with Crit Exp segments (24h) - WIP

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -22,20 +22,51 @@ if [ $# -gt 0 ]; then
   fi
 fi
 
+time_segment() {
+  hour="$1"
+  segment=$(( (hour / 6) * 2 + (hour % 6 < 5 ? 0 : 1) ))
+  echo "$segment"
+}
+
+is_next_hour_in_new_segment() {
+  hour="$1"
+  current_segment=$(time_segment "$hour")
+  next_hour=$((hour + 1))
+  if [[ "$next_hour" -gt 23 ]]; then
+    echo 1
+    return
+  fi
+  next_segment=$(time_segment "$next_hour")
+  if [[ "$current_segment" -ne "$next_segment" ]]; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
 # Note that we use UTC time (-u)
-day=$(date -u "${delta[@]}" +%d)
 month=$(date -u "${delta[@]}" +%-m)
 year=$(date -u "${delta[@]}" +%y)
+hour=$(date -u "${delta[@]}" +%H)
 
-if [ "$day" -ge 0 ] && [ "$day" -le 7 ]; then
-  week=1
-elif [ "$day" -ge 8 ] &&  [ "$day" -le 14 ]; then
-  week=2
-elif [ "$day" -ge 15 ] &&  [ "$day" -le 21 ]; then
-  week=3
-elif [ "$day" -ge 22 ] && [ "$day" -le 28 ]; then
-  week=4
-elif [ "$day" -ge 29 ] && [ "$day" -le 35 ]; then
-  week=5
+# the idea is that we will create a new release at the end of the last hour of a segment
+# ideally around 55 - 59 minutes into the hour (since deployment might take 5 minutes)
+# TODO: if our cron scheduling can run late we may need to either A) adjust time / round dow to previous hour
+# or B) get release version at the very start of deploy.sh so that if deployment takes long we don't switch
+# to next hour.
+result=$(is_next_hour_in_new_segment "$hour")
+if [ "$result" -eq 0 ]; then
+  # keep going back 1 hour until we find a new segment or hit 0
+  while [ "$result" -eq 0 ] && [ "$hour" -gt 0 ]; do
+    hour=$((hour - 1))
+    result=$(is_next_hour_in_new_segment "$hour")
+  done
+  # if hour is not 0 go 1 hour forward
+  if [ "$hour" -ne 0 ]; then
+    hour=$((hour + 1))
+  fi
 fi
-echo "$year.$month.$week"
+
+month_hour=$(( ($(date -u +%d) - 1) * 24 + $hour )) # from 0 to 743
+
+echo "$year.$month.$month_hour"


### PR DESCRIPTION
this is just a quick prototype, only `time_segment()` and `is_next_hour_in_new_segment()` have been tested the rest of the code was not even run

Actually might not need the backtracking logic as we already have this
https://github.com/sentry-demos/empower/blob/4d0bb001dbe73ba5b55a4564d8cfe8a5e5790304/.github/workflows/auto-deploy.yml#L136

# Related
https://github.com/sentry-demos/empower/blob/4d0bb001dbe73ba5b55a4564d8cfe8a5e5790304/tda/conftest.py#L271