### PR TITLE
[platform] fix envsubst handling of escaped \$

### DIFF
--- a/bin/envsubst.sh
+++ b/bin/envsubst.sh
@@ -2,6 +2,10 @@
 
 envsubst_() {
   local input="$1"
+  # First, replace \$ with a unique placeholder that won't appear in normal text
+  local placeholder=$'\x01ESCAPED_DOLLAR\x02'
+  input="${input//\\\$/$placeholder}"
+
   local output=""
   local i=0
   local len=${#input}
@@ -55,7 +59,8 @@ envsubst_() {
     output="$output${!var_name}"
   fi
 
-  printf "%s\n" "$output"
+  # Convert the placeholder back to $
+  printf "%s\n" "${output//$placeholder/$}"
 }
 
 # Process the entire input file


### PR DESCRIPTION
was breaking `app.yaml.template` in `ruby-on-rails`
https://github.com/sentry-demos/empower/blob/aec789c56c24a13a3ac2091ac271919ae561c699/ruby-on-rails/app.yaml.template#L1

# Testing
./deploy.sh --env=staging ruby-on-rails
http://staging-application-monitoring-rails.sales-engineering-sf.appspot.com/products