### PR TITLE
[release] fix sourcemap <-> release association

### DIFF
--- a/bin/envsubst.sh
+++ b/bin/envsubst.sh
@@ -64,6 +64,6 @@ envsubst_() {
 }
 
 # Process the entire input file
-while IFS= read -r line; do
+while IFS= read -r line || [ -n "$line" ]; do
   envsubst_ "$line"
 done

--- a/react/build.sh
+++ b/react/build.sh
@@ -4,7 +4,9 @@
 
 set -e # exit immediately if any command exits with a non-zero status
 
-envsubst < config-overrides.js.template > config-overrides.js
+envsubst.sh < config-overrides.js.template > config-overrides.js
+
+export SENTRY_RELEASE=$RELEASE
 
 rm -rf build
 # npm ci does not update minor versions ->


### PR DESCRIPTION
also switched to portable envsubst and fixed another edge case in it (no newline at end of template file)

# Testing
<img width="710" alt="Screenshot 2025-04-08 at 2 12 44 PM" src="https://github.com/user-attachments/assets/46d21eda-1e7f-46d8-9138-ebf08112147c" />


```
./deploy.sh --env=staging react
.
.
.

[sentry-webpack-plugin] Info: Sending telemetry data on issues and performance to Sentry. To disable telemetry, set `options.telemetry` to `false`.
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
> Found 2 files
> Analyzing 2 sources
> Analyzing completed in 0.015s
> Adding source map references
> Bundling completed in 0.131s
> Bundled 2 files for upload
> Bundle ID: 51c9329d-47ff-54b9-a048-1d0655748d23
> Optimizing completed in 0.005s
> Nothing to upload, all files are on the server
> Processing completed in 0.208s
> File processing complete
> Organization: demo
> Project: staging-react
> Release: application.monitoring.javascript@25.4.2
> Dist: None
> Upload type: artifact bundle

Source Map Upload Report
  Scripts
    ~/51fc0388-dded-4623-80d1-ac4de1d94187-0.js (sourcemap at main.1aa4dab4.js.map, debug id 51fc0388-dded-4623-80d1-ac4de1d94187)
  Source Maps
    ~/51fc0388-dded-4623-80d1-ac4de1d94187-0.js.map (debug id 51fc0388-dded-4623-80d1-ac4de1d94187)
[sentry-webpack-plugin] Info: Successfully uploaded source maps to Sentry
Compiled with warnings.

.
.
.
```