### PR TITLE
add 1s to time.sleep

### DIFF
--- a/tda/mobile_native/android/test_checkout_android.py
+++ b/tda/mobile_native/android/test_checkout_android.py
@@ -16,8 +16,8 @@ def test_checkout_android(android_emu_driver):
         # Checkout button
         android_emu_driver.find_element(AppiumBy.ID, 'com.example.vu.android:id/checkout_btn').click()
 
-        # Sleep in seconds to allow time for error to send to Sentry (minimum 2, tested 4/26/2023 sz)
-        time.sleep(2)
+        # Sleep in seconds to allow time for error to send to Sentry (minimum 3, tested 4/8/2025 sz)
+        time.sleep(3)
 
     except Exception as err:
         sentry_sdk.capture_exception(err)


### PR DESCRIPTION
**Experiment details**

Run `python3 -m pytest -n 1 mobile_native/android/test_checkout_android.py` with different conditions:

1. No change: [Replay](https://demo.sentry.io/replays/76a4a278b57e407580a7d4fccf14e67c/?referrer=%2Fissues%2F%3AgroupId%2Fevents%2F%3AeventId%2F&t=3.144300000011921&t_main=errors), where no flagship error appears as expected
2. Change from `2` to `3` (in `time.sleep(3)`): [Replay](https://demo.sentry.io/replays/0fa42fe5302644639c98ac6449b0d0bd/?referrer=%2Fissues%2F%3AgroupId%2Fevents%2F%3AeventId%2F&t=4.7679000000357625&t_main=errors), where the [MainFragment$BackendAPIException](https://demo.sentry.io/issues/6530181600/events/9de3f96cddc148f7921687aa7b07f318/?project=4508968118321152&referrer=replay-errors) appears as expected

Therefore, change `time.sleep(2)` to `time.sleep(3)` fixes https://github.com/sentry-demos/empower/issues/775