### PR TITLE
Updated URLs for Session Replay network details

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -99,7 +99,7 @@ Sentry.init({
       // replaysSessionSampleRate and replaysOnErrorSampleRate is now a top-level SDK option
       blockAllMedia: false,
       // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details
-      networkDetailAllowUrls: ['/checkout', '/products'],
+      networkDetailAllowUrls: [/.*/],
       unmask: [".sentry-unmask"],
     }),
   ],


### PR DESCRIPTION
Added all urls to `networkDetailAllowUrls` configuration to see Response and Request information at Session Replay Network -> Response/Request tabs