### PR TITLE
Fix failing staging deployments + google secret manager

### DIFF
--- a/bin/sentry-release.sh
+++ b/bin/sentry-release.sh
@@ -21,11 +21,12 @@ if [[ "$env" == "" || "$release" == "" || "$upload_sourcemaps" == "" ]]; then
 fi
 
 proj=$(basename $(pwd))
-    
+
 if [ "$SENTRY_ORG" == "" ]; then
   echo "$0 [ERROR] SENTRY_ORG must be defined in ./env-config/$env.env."
   exit 1
 fi
+
 # sets $sentry_project var to the value of e.g. REACT_SENTRY_PROJECT from env-config/<env>.env
 . get_proj_var.sh "%s_SENTRY_PROJECT" $proj
 if [ "$upload_sourcemaps" == "true" ]; then

--- a/bin/validate_dotenv.sh
+++ b/bin/validate_dotenv.sh
@@ -6,13 +6,13 @@
 # For React specifically:
 #
 #   REACT_APP_MY_VAR=foobar npm run build
-# 
+#
 #   Names must be prefixed with 'REACT_APP_', otherwise they will not show up
 #
 #   See https://create-react-app.dev/docs/adding-custom-environment-variables
 
 set -e # exit immediately if any command exits with a non-zero status
-  
+
 if [ ! -f .env ]; then
     >&2 echo "$0: ERROR: .env does not exist in current directory: $(pwd). It should have been
     created by 'parent' script."
@@ -20,4 +20,3 @@ if [ ! -f .env ]; then
 fi
 
 env -i PATH="$PATH" SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" /bin/bash -c 'export $(grep -v ^# .env | sed "s/ #.*//" | xargs); validate_env.sh'
- 

--- a/bin/validate_env.sh
+++ b/bin/validate_env.sh
@@ -8,8 +8,9 @@
 
 set -e # exit immediately if any command exits with a non-zero status
 
+echo "[INFO] Validating environment variables..." >&2
 if [ ! -f validate_env.list ]; then
-  >&2 echo "$0: ERROR: validate_env.list file does not exist in current directory: $(pwd)"
+  >&2 echo "$0: [ERROR] validate_env.list file does not exist in current directory: $(pwd)"
   exit 1
 fi
 
@@ -22,17 +23,17 @@ for var in $(grep -v '^#' validate_env.list | xargs); do
   # Other possible methods:
   #   value=$(printenv $var)
   #   match=$(grep -e "^$var=" .env | cut -d '=' -f 2)
-  
+
   value="${!var}" # won't work in zsh, only bash
 
   if [ "$value" == "" ]; then
     >&2 echo "$0: [ERROR] required env variable $var not defined or has empty value.
       You must add it to your env-config/*.env file. Correct values can be obtained from
-      https://github.com/sentry-demos/application-monitoring-config" 
+      https://github.com/sentry-demos/application-monitoring-config"
     exit 1
   fi
-done 
-  
+done
+
 #proj=$(basename $(pwd))
 #. get_proj_var.sh "%s_APP_DSN" $proj
 #. get_proj_var.sh "%s_SENTRY_PROJECT" $proj

--- a/deploy.sh
+++ b/deploy.sh
@@ -187,10 +187,11 @@ for proj in $projects; do # bash only
 
   cd $top/$proj
 
-  # React builds env vars in; Express/Flask need .env at runtime.
+  # React "bakes in" env variables (exported from calling shell) as well as contents 
+  # of .env into the build, whereas Express/Flask need .env at runtime
   # We dynamically generate a temporary .env from env-config/$env.env.
-  # This command calls ../env.sh, which also validates env vars listed in
-  # the project's validate_env.list via bin/validate_dotenv.sh -> bin/validate_env.sh.
+  # env.sh among other things validates env vars listed in the project's validate_env.list
+  # via bin/validate_dotenv.sh -> bin/validate_env.sh.
   generated_envs+="$(../env.sh $env) "
 
   # We do this because 1) we need RELEASE that's generated in env.sh 2) we need *_APP_*_BACKEND

--- a/deploy.sh
+++ b/deploy.sh
@@ -118,18 +118,79 @@ for proj in $projects; do # bash only
   echo "||| $0: $proj"
   echo "|||"
 
+  # Function to fetch secrets from Google Cloud Secret Manager (uses same name for env var and secret)
+  fetch_secrets_to_env() {
+    # Check if gcloud is available
+    if ! command -v gcloud &> /dev/null; then
+      echo "[ERROR] gcloud command not found, skipping secret fetching"
+      return 1
+    fi
+
+    echo "Fetching secrets from Google Cloud Secret Manager for environment: $env..."
+
+    # Define the list of secrets to fetch - names will be identical in env and Secret Manager
+    local secrets=(
+      "STATSIG_CLIENT_KEY"
+      "STATSIG_SERVER_KEY"
+    )
+
+    # Add environment-specific Sentry token
+    local sentry_token_name
+    case "$env" in
+      "prod")
+        sentry_token_name="SENTRY_AUTH_TOKEN_PROD_DEMO"
+        ;;
+      "staging")
+        sentry_token_name="SENTRY_AUTH_TOKEN_STAGING_TEAM_SE"
+        ;;
+      "local")
+        echo "[INFO] Skipping auth token fetching for local environment"
+        ;;
+      *)
+        echo "[ERROR] Unknown environment '$env'"
+        exit 1
+    esac
+
+    # Add Sentry token to secrets list if we're in prod/staging
+    if [ -n "$sentry_token_name" ]; then
+      secrets+=("$sentry_token_name")
+    fi
+
+    # Fetch each secret and export it to environment
+    for secret_name in "${secrets[@]}"; do
+      echo "  Fetching secret $secret_name..."
+
+      # Fetch the secret value
+      local value
+      value=$(gcloud secrets versions access latest --secret="$secret_name" --project=sales-engineering-sf 2>/dev/null)
+
+      if [ $? -ne 0 ]; then
+        echo "[ERROR] Failed to fetch secret '$secret_name', skipping"
+        exit 1
+      else
+        # For Sentry tokens, always export as SENTRY_AUTH_TOKEN regardless of secret name
+        if [[ "$secret_name" == "SENTRY_AUTH_TOKEN"* ]]; then
+          export "SENTRY_AUTH_TOKEN=$value"
+          echo "  Successfully set SENTRY_AUTH_TOKEN"
+        else
+          export "$secret_name=$value"
+          echo "  Successfully set $secret_name"
+        fi
+      fi
+    done
+  }
+
+  # Fetch secrets before validating project
+  fetch_secrets_to_env
+
   validate_project.sh $top/$proj
 
   cd $top/$proj
 
-  # React bakes in (exported) env variables from calling shell as well as contents of .env
-  # at build time into the static build output. As a result it doesn't need .env at runtime.
-  # See: https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/config/env.js
-  # and https://create-react-app.dev/docs/adding-custom-environment-variables/
-  #
-  # Express and Flask on the other hand need .env deployed and present at runtime.
-  #
-  # We generate a temporary .env dynamically from env-config/*.env then remove upon exit
+  # React builds env vars in; Express/Flask need .env at runtime.
+  # We dynamically generate a temporary .env from env-config/$env.env.
+  # This command calls ../env.sh, which also validates env vars listed in
+  # the project's validate_env.list via bin/validate_dotenv.sh -> bin/validate_env.sh.
   generated_envs+="$(../env.sh $env) "
 
   # We do this because 1) we need RELEASE that's generated in env.sh 2) we need *_APP_*_BACKEND
@@ -170,6 +231,7 @@ for proj in $projects; do # bash only
   unset CI # prevents build failing in GitHub Actions
   ./build.sh
 
+
   if [[ $proj =~ ^(react|next|vue|flask)$ ]]; then # Suspect Commits now require commits associated w/ release
     if [[ $proj =~ ^(react|next|flask)$ ]]; then
       upload_sourcemaps="false" # using webpack plugin or doesn not apply
@@ -178,13 +240,6 @@ for proj in $projects; do # bash only
     fi
     sentry-release.sh $env $RELEASE $upload_sourcemaps
     # NOTE: Sentry may create releases from events even without this step
-  fi
-
-  # If gcloud is installed, use it to get the sentry auth token from Google Cloud Secret Manager.
-  # Sentry CLI will use this token for authentication.  Otherwise, one can use `sentry-cli login`,
-  # but that will not work when deploying to staging or production.
-  if command -v gcloud &> /dev/null ; then
-    export SENTRY_AUTH_TOKEN=$(gcloud secrets versions access latest --secret="SENTRY_AUTH_TOKEN")
   fi
 
   # *** DEPLOY OR RUN ***

--- a/env.sh
+++ b/env.sh
@@ -29,7 +29,7 @@ fi
 if [ -f ".env" ]; then
     >&2 echo "[ERROR] project '$proj' contains legacy .env file that is no longer used. Please delete this file,
     it is no longer needed and has been replaced by ./env-config/*.env. Note that this error
-    might also happen if deploy.sh or env.sh failed to clean up the .env file it has generated dynamically 
+    might also happen if deploy.sh or env.sh failed to clean up the .env file it has generated dynamically
     during an earlier run."
     exit 1
 fi
@@ -75,7 +75,7 @@ fi
 
 validate_dotenv.sh
 
-if [ "$2" == "" ]; then 
+if [ "$2" == "" ]; then
     # Called from deploy.sh
     #
     # 1. Calling script will use .env, this script doen't have control over that.
@@ -83,7 +83,7 @@ if [ "$2" == "" ]; then
     # 2. We can't export variables into calling script, so the calling script is
     # also responsible for that (not required for projects using dotenv package).
     trap - EXIT
-    echo "$(pwd)/.env" 
+    echo "$(pwd)/.env"
 else
     # Standalone mode
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d89ffb8a-2e21-4c8f-b829-56843ea7cefd)


- migration to team-se requires new sentry auth token
- added auth token in gcloud
- updated script to conditionally fetch based on env
- moved auth token fetching to be before source maps upload to fix org mismatch deployment bug
  - may have only existed on my local but we need to override whatever is in SENTRY_AUTH_TOKEN with the correct env secret
- updated validate_env for better logging

 TESTING
- Successfully deployed locally + staging