### PR TITLE
[tda,react-native] update selectors to match latest app release

### DIFF
--- a/tda/mobile_native/android_react_native/test_captureexception_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_captureexception_react_native_android.py
@@ -5,7 +5,7 @@ def test_captureexception_react_native_android(android_react_native_emu_driver):
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text=""]').click()
 
         # trigger exception
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Capture Exception"]')

--- a/tda/mobile_native/android_react_native/test_capturemessage_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_capturemessage_react_native_android.py
@@ -5,7 +5,7 @@ def test_capturemessage_react_native_android(android_react_native_emu_driver):
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text=""]').click()
 
         # trigger message
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Capture Message"]')

--- a/tda/mobile_native/android_react_native/test_checkout_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_checkout_react_native_android.py
@@ -10,7 +10,7 @@ def test_checkout_react_native_android(android_react_native_emu_driver):
         add_to_cart_btn.click()
 
         # Click cart at bottom
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[2]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@resource-id="bottom-tab-cart"]').click()
 
         # checkout button
         android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'CHECKOUT').click()
@@ -26,7 +26,8 @@ def test_checkout_react_native_android(android_react_native_emu_driver):
         android_react_native_emu_driver.scroll(bottom_of_screen_element, top_of_screen_element)
 
         # Place order button
-        android_react_native_emu_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Place your order').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.view.ViewGroup[@content-desc="Place your order"]').click()
+        # text element of the button is '//android.widget.TextView[@text="Place your order"]'
 
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/tda/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -5,7 +5,7 @@ def test_homescreen_react_native_android(android_react_native_emu_driver, random
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text=""]').click()
 
         # Handled Exceptions - This clicks the Handled Exception' button in the app
         # This error type does not increment the Crash Count for the release,

--- a/tda/mobile_native/android_react_native/test_nativecrash_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_nativecrash_react_native_android.py
@@ -5,7 +5,7 @@ def test_nativecrash_react_native_android(android_react_native_emu_driver):
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text=""]').click()
 
         # trigger crash
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Native Crash"]')

--- a/tda/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -5,7 +5,7 @@ def test_uncaughtthrownerror_react_native_android(android_react_native_emu_drive
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text=""]').click()
 
         # trigger error
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Uncaught Thrown Error"]')

--- a/tda/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tda/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -5,7 +5,7 @@ def test_unhandledpromiserejection_react_native_android(android_react_native_emu
 
     try:
         # click into list app screen
-        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.View/android.view.View[3]').click()
+        android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text=""]').click()
 
         # trigger error
         btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '//android.widget.TextView[@text="Unhandled Promise Rejection"]')


### PR DESCRIPTION
This fixes most of the tests except test_checkout, which still has 1 remaining regression.

test_checkout still doesn't quite work because scrolling stopped working:

https://github.com/sentry-demos/empower/blob/master/tda/mobile_native/android_react_native/test_checkout_react_native_android.py#L26

# Testing

https://app.saucelabs.com/dashboard/tests?build=rn-pr100-3&platform=Android+15&platform=Android+12&platform=Android+10&ownerId=myorganization&ownerType=organization&ownerName=My+organization&start=today