### PR TITLE
[flask, seer] autofixable flagship error - UnboundLocalError - OPTION 2 [chained]

### DIFF
--- a/flask/src/db.py
+++ b/flask/src/db.py
@@ -158,7 +158,8 @@ def get_inventory(cart):
 
     return inventory
 
-
+def decrement_inventory(id, count):
+    pass
 
 def formatArray(ids):
     numbers = ""

--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -231,9 +231,9 @@ def checkout():
                         fulfilled_count += 1
                     else:
                         out_of_stock.push(f'Item #{i}')
-    except Exception:
+    except Exception as err:
         sentry_sdk.metrics.incr(key="checkout.failed")
-        raise
+        raise Exception("Error validating enough inventory for product") from err
 
     if len(out_of_stock) == 0:
         result = {'status': 'success'}

--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -12,7 +12,7 @@ from flask_caching import Cache
 from statsig.statsig_user import StatsigUser
 from statsig import statsig, StatsigOptions, StatsigEnvironmentTier
 import dotenv
-from .db import get_products, get_products_join, get_inventory
+from .db import decrement_inventory, get_products, get_products_join, get_inventory
 from .utils import parseHeaders, get_iterator, evaluate_statsig_flags
 from .queues.tasks import sendEmail
 import sentry_sdk
@@ -208,25 +208,42 @@ def checkout():
         with sentry_sdk.start_span(op="/checkout.get_inventory", description="function"):
             with sentry_sdk.metrics.timing(key="checkout.get_inventory.execution_time"):
                 inventory = get_inventory(cart)
+                # id | sku | count | productid
     except Exception as err:
         raise (err)
 
     logging.info("> /checkout inventory %s", inventory)
     logging.info("> validate_inventory %s", validate_inventory)
 
-    with sentry_sdk.start_span(op="process_order", description="function"):
-        quantities = cart['quantities']
-        for cartItem in quantities:
-            for inventoryItem in inventory:
-                logging.debug("> inventoryItem.count %s", inventoryItem['count'])
-                if (validate_inventory and (inventoryItem.count < quantities[cartItem] or quantities[cartItem] >= inventoryItem.count)):
-                    sentry_sdk.metrics.incr(key="checkout.failed")
-                    raise Exception('Not enough inventory for product')
-        if len(inventory) == 0 or len(quantities) == 0:
-            raise Exception("Not enough inventory for product")
+    fulfilled_count = 0
+    out_of_stock = [] # list of items that are out of stock
+    try:
+        with sentry_sdk.start_span(op="process_order", description="function"):
+            if validate_inventory:
+                if len(quantities) == 0:
+                    raise Exception("Invalid checkout request")
 
-    response = make_response("success")
-    return response
+                quantities = cart['quantities']
+                inventoryDict = {x.productid: x for x in inventory}
+                for i, cartItem in enumerate(quantities):
+                    if cartItem in inventoryDict and inventoryDict[cartItem].count >= quantities[cartItem]:
+                        decrement_inventory(inventoryDict[cartItem].id, quantities[cartItem])
+                        fulfilled_count += 1
+                    else:
+                        out_of_stock.push(f'Item #{i}')
+    except Exception:
+        sentry_sdk.metrics.incr(key="checkout.failed")
+        raise
+
+    if len(out_of_stock) == 0:
+        result = {'status': 'success'}
+    else:
+        if fulfilled_count == 0:
+            result = {'status': 'failed'} # All items are out of stock
+        else: 
+            result = {'status': 'partial', 'out_of_stock': out_of_stock}
+    
+    return make_response(json.dumps(result))
 
 
 @app.route('/success', methods=['GET'])

--- a/flask/src/main.py
+++ b/flask/src/main.py
@@ -218,8 +218,8 @@ def checkout():
     fulfilled_count = 0
     out_of_stock = [] # list of items that are out of stock
     try:
-        with sentry_sdk.start_span(op="process_order", description="function"):
-            if validate_inventory:
+        if validate_inventory:
+            with sentry_sdk.start_span(op="process_order", description="function"):
                 if len(quantities) == 0:
                     raise Exception("Invalid checkout request")
 


### PR DESCRIPTION
Implemented as chained exception (`raise ... from ...`). This way SEs are not confused and will see familiar-ish inventory error. Same can be done for Option 1 (https://github.com/sentry-demos/empower/pull/857)

This is designed not to break Critical Experiences (see `validate_inventory`)

This is mutually exclusive with Option 1 (https://github.com/sentry-demos/empower/pull/857) we have to pick one or the other depending on which one provides a better Seer demo.

<img width="797" alt="Screenshot 2025-06-13 at 4 16 17 PM" src="https://github.com/user-attachments/assets/ccf395dc-2ed0-4982-87b3-1b5519671c1f" />

# Testing
### standard_checkout_fail
http://localhost:3000/?cexp=standard_checkout_fail&se=unboundlocalerror2-cexp-standard_checkout_fail

<img width="318" alt="Screenshot 2025-06-13 at 3 50 01 PM" src="https://github.com/user-attachments/assets/463146e8-e706-409c-b10e-a96425b818e2" />

[flagship error, N+1 query](https://kosty.sentry.io/issues/?project=4506005091319808&query=se%3Aunboundlocalerror2-cexp-standard_checkout_fail&referrer=issue-list&statsPeriod=30d)

###  checkout_success
http://localhost:3000/?cexp=checkout_success&se=unboundlocalerror2-cexp-checkout_success

<img width="290" alt="Screenshot 2025-06-13 at 3 46 47 PM" src="https://github.com/user-attachments/assets/3bb9db12-8e59-4779-88a3-e9db06c5a13d" />

[no errors, only N+1 query](https://kosty.sentry.io/issues/?project=4506005091319808&query=is%3Aunresolved%20se%3Aunboundlocalerror2-cexp-checkout_success&referrer=issue-list&statsPeriod=30d)
