### PR TITLE
removed metrics call from checkout form

### DIFF
--- a/next/src/ui/checkout/CheckoutForm.jsx
+++ b/next/src/ui/checkout/CheckoutForm.jsx
@@ -38,7 +38,6 @@ export function CheckoutForm({ cart, checkoutAction }) {
           behavior: 'auto',
         });
 
-        Sentry.metrics.increment('checkout.click');
         console.log("> cart", cart);
         // Server Action within a client component
         // Reference: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations


### PR DESCRIPTION
## Changes

- Removed Sentry metrics call that was breaking checkout error flow
- Metrics are no longer supported in the next sdk

## How to Test

- Navigate to branch on vercel
- Walk through checkout process, observe expected error 