### PR TITLE
[tda,react] Chrome with Firefox user-agent instead of actual Firefox

### DIFF
--- a/tda/config.yaml
+++ b/tda/config.yaml
@@ -7,10 +7,11 @@ browsers:
   platformName: Windows 10
   param_display: chrome_windows
 - remote: true
-  browserName: firefox
+  browserName: chrome
   browserVersion: latest
   platformName: Windows 10
-  param_display: firefox_windows
+  param_display: fake_firefox_windows
+  userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:139.0) Gecko/20100101 Firefox/139.0
 ## commenting out safari for now as it's not loading up empower-app as expected
 ## see `sauceLabsUrl`s in https://demo.sentry.io/issues/5275523263/?project=5390094
 # - remote: true

--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -65,6 +65,7 @@ class Browser(NamedTuple):
     browserVersion: str | None = None
     platformName: str | None = None
     param_display: str | None = None
+    userAgent: str | None = None
 
 
 class Config(NamedTuple):
@@ -374,6 +375,11 @@ def _sauce_browser(request, selenium_endpoint, se):
 
         options.set_capability('platformName', request.param.platformName)
         options.set_capability('browserVersion', request.param.browserVersion)
+        
+        # Set custom user agent if provided
+        if request.param.userAgent:
+            options.add_argument(f'user-agent={request.param.userAgent}')
+            
         options.set_capability('sauce:options', {
             'seleniumVersion': '4.8.0',
             'build': build_tag,
@@ -430,6 +436,11 @@ def _local_browser(request, se):
     options.add_argument("disable-gpu")
     options.add_argument("disable-dev-shm-usage")
     options.add_argument("headless")
+    
+    # Set custom user agent if provided
+    if request.param.userAgent:
+        options.add_argument(f'user-agent={request.param.userAgent}')
+        
     with ChromeWithExtraUrlParams(
             options=options,
             extra_params=urlencode({'se': se}),


### PR DESCRIPTION
# Problem 

For a number of months now  now due to some change in Firefox the stacktrace for flagship error coming from FF looked different and as a result created a separate issue. Additionally @thinkocapo reported that the Firefox issue was missing suspect commit.

<img width="1711" alt="image (64)" src="https://github.com/user-attachments/assets/d10188f0-be1e-4a62-ae55-2c41487478ee" />

# Testing

<img width="988" alt="Screenshot 2025-06-18 at 9 39 07 AM" src="https://github.com/user-attachments/assets/8d0c9ab3-1a1b-4ac4-a2a0-57ffd39bf1b1" />

That issue includes both browsers
<img width="634" alt="Screenshot 2025-06-18 at 9 37 49 AM" src="https://github.com/user-attachments/assets/82549638-3cd3-4d81-8b80-28ab83ab356d" />

Suspect commit shows up on Firefox event:
<img width="919" alt="Screenshot 2025-06-18 at 9 38 05 AM" src="https://github.com/user-attachments/assets/dde14a16-57ad-4f00-bfcd-c224bdbfe8a7" />




