### PR TITLE
[react] only split fingerprint by SE/Release for 5xx errors

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -116,7 +116,9 @@ Sentry.init({
       se = scope._tags.se;
     });
 
-    if (se) {
+    let is5xxError = event.exception && /^5\d{2} - .*$/.test(event.exception.values[0].value);
+    if (se && is5xxError) {
+      // Create a separate issue for each SE and RELEASE combination
       const seTdaPrefixRegex = /[^-]+-tda-[^-]+-/;
       let seFingerprint = se;
       let prefix = seTdaPrefixRegex.exec(se);


### PR DESCRIPTION
Reduce noise in issue stream, consolidate unintended errors.

We only need this AFAIK to enable SE demo live notification flow and show "New Issues" in Release Health. Just breaking up `500 - Internal Server Error` issues should be sufficient.

# Testing
`./deploy.sh --env=local react` 

<img width="756" alt="Screenshot 2025-06-24 at 11 52 18 AM" src="https://github.com/user-attachments/assets/584e0e28-408a-4f60-83c3-66be31da3cd4" />


<img width="896" alt="Screenshot 2025-06-24 at 11 42 11 AM" src="https://github.com/user-attachments/assets/0770eb26-1970-46ea-a92f-13b9fdf543a6" />
