### PR TITLE
[tda] always re-install requirements.txt when deploying

### DIFF
--- a/tda/build.sh
+++ b/tda/build.sh
@@ -2,6 +2,7 @@
 
 set -e 
 #virtualenv --python=`which python3.8` env
+rm -rf env || true
 python3.10 -m venv env
 source env/bin/activate 
 pip install -r requirements.txt

--- a/tda/deploy_tda.sh
+++ b/tda/deploy_tda.sh
@@ -59,7 +59,7 @@ fi
 echo "Log directory permissions set up."
 
 # setting permissions with rscync doesn't work, leaves 775 instead of 777 (umask?)
-ssh $HOST 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
+ssh $HOST 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/empower-tda/env/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
 
 echo "Installing requirements..."
 # Host must have python3.8 and virtualenv installed

--- a/tda/deploy_tda.sh
+++ b/tda/deploy_tda.sh
@@ -17,17 +17,6 @@ fi
 
 trap - EXIT
 
-reqs_changed=0
-env_nonempty=0
-echo "Checking state of current deployment..."
-diff -q requirements.txt <(ssh $HOST 'cat '$DIR'/requirements.txt')
-if [ $? == 1 ]; then # files differ or failed to compare
-  reqs_changed=1
-fi
-if ssh $HOST '[[ -d '"$DIR/env"' ]] && [[ ! -z `ls -A '"$DIR/env"'` ]]'; then
-  env_nonempty=1
-fi
-
 echo "Copying code to remote directory..."
 # for whatever reason can't delete or chmod __pycache__ directories
 rsync -rz --delete --force-delete --exclude env/ --exclude __pycache__ --exclude .pytest_cache * .sauce_credentials $HOST:$DIR/
@@ -70,18 +59,14 @@ fi
 echo "Log directory permissions set up."
 
 # setting permissions with rscync doesn't work, leaves 775 instead of 777 (umask?)
-ssh $HOST 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/empower-tda/env/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
+ssh $HOST 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
 
-if [[ $reqs_changed == "1" || $env_nonempty == "0" ]]; then
-  echo "re-installing requirements (because requirements.txt changed OR 'env' directory does not exist or is empty)..."
-  # Host must have python3.8 and virtualenv installed
-  ssh $HOST 'cd '$DIR' && ./build.sh'
-  if [ $? != 0 ]; then
-    echo "[ERROR] failed to install requirements on destination host"
-    exit 1
-  fi
-else
-  echo "No need to install requirements, because no changes to requirements.txt, env exists on remote host and is not empty."
+echo "Installing requirements..."
+# Host must have python3.8 and virtualenv installed
+ssh $HOST 'cd '$DIR' && ./build.sh'
+if [ $? != 0 ]; then
+  echo "[ERROR] failed to install requirements on destination host"
+  exit 1
 fi
 
 set -e


### PR DESCRIPTION
# Context
Trying to fix this:
https://github.com/sentry-demos/empower/actions/runs/16126796262/job/45505551185
```
Error: [Errno 13] Permission denied: '/home/kosty/empower-tda/env/bin/activate.fish'
```

seems like when running  `./deploy_tda.sh` locally from my laptop it used a different user (`kosty`) to create `activate.fish` than the user when the script is run in GHA (user: `runner`). Not sure why that file was created... probably Ubuntu auto-updated minor version of `python3.10` and its `venv` module started supporting this new shell... 

# Testing 
```
cd tda && ./deploy_tda.sh
```

# Solution
Go nuclear and delete entire `env` dir during every deployment

# Note
not touching this line as it's probably there for a reason...
```
ssh $HOST 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/empower-tda/env/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
```