### PR TITLE
[tda] fix permissions for logrotate after package version upgrade

### DIFF
--- a/tda/deploy_tda.sh
+++ b/tda/deploy_tda.sh
@@ -34,7 +34,7 @@ fi
 echo "Code copied."
 
 echo "Copying logrotate configuration..."
-ssh $HOST 'sudo cp '$DIR'/logrotate.d/tda /etc/logrotate.d/tda && sudo sed -i "s/create 0640 replace_with_user replace_with_user/create 0640 $USER $USER/" /etc/logrotate.d/tda'
+ssh $HOST 'sudo cp '$DIR'/logrotate.d/tda /etc/logrotate.d/tda && sudo sed -i "s/create 0640 replace_with_user replace_with_user/create 0640 $USER $USER/" /etc/logrotate.d/tda && sudo sed -i "s/su replace_with_user replace_with_user/su $USER $USER/" /etc/logrotate.d/tda'
 if [ $? != 0 ]; then
   echo "[ERROR] Failed to copy logrotate configuration to remote host."
   exit 1

--- a/tda/logrotate.d/tda
+++ b/tda/logrotate.d/tda
@@ -12,5 +12,7 @@
     # Copy the original log file and then truncate it (avoids needing to restart process but may lead to minor data loss)
     copytruncate
     # Create a new log file with these permissions, owner, and group.
-    create 0640 replace_with_user replace_with_user 
+    create 0640 replace_with_user replace_with_user
+    # Use specific user/group for rotation to handle insecure parent directory permissions
+    su replace_with_user replace_with_user
 }


### PR DESCRIPTION
this broke after `sudo apt upgrade` + reboot

# Testing
`./deploy_tda.sh`