### PR TITLE
Update README.md

### DIFF
--- a/tda/README.md
+++ b/tda/README.md
@@ -73,23 +73,9 @@ kill -9 <PID of the script.sh>
 1. Test that `gcloud compute ssh empower-tda-and-crons` works
 2. Run `gcloud compute config-ssh` to add any new instances to your `~/.ssh/config`
 
-### TypeError: required field "lineno" missing from alias
-```
-  File "/Users/kosty/home/empower/tda/env/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 360, in _rewrite_test
-    co = compile(tree, fn_, "exec", dont_inherit=True)
-TypeError: required field "lineno" missing from alias
-```
-You will need to downgrade your python version to fix this:
-1. Install Python 3.10 with `brew install python@3.10` (macos) or google "install python 3.10 linux" for `apt-get` instructions for GCP VM.
-2. Nuke your `venv`-created `env`: `deactivate && rm -rf env`
-3. `pip3 install virtualenv` or `python3 -m pip install virtualenv`, etc.
-4. Create a virtual environment that uses Python 3.10 instead of your global python `virtualenv --python="/opt/homebrew/Cellar/python@3.10/3.10.??/bin/python3.10" env` (exact path may differ, might be able to find it with `which python3.10` command)
-5. The usual:
-```
-source env/bin/activate
-pip install -r requirements.txt
-```
-6. Instead of using `py.test` or `pytest` executable that is probably global and points to your Python 3.10+ installation, use `python3 -m pytest` that will pick up the Python 3.10 from virtual environment. (Not an issue on GCP tda box)
+### Other
+
+Instead of using `py.test` or `pytest` executable that is probably global and could use the wrong python minor version, use `python3 -m pytest` that will pick up the Python 3.10 from virtual environment. (was not an issue on GCP tda box)
 
 Note that handled errors will not increment the crash counts in Release Health. But the Release Health UI does separate Handled from Unhandled Issues.
 


### PR DESCRIPTION
Get rid of python3.10 Troubleshooting in README.md since we upgraded to 3.12 successfully

see https://github.com/sentry-demos/empower/pull/926