### PR TITLE
[tda,ruby] clean up backend(exclude='ruby') now that we removed it entirely

### DIFF
--- a/tda/desktop_web/test_checkout.py
+++ b/tda/desktop_web/test_checkout.py
@@ -15,8 +15,7 @@ def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sl
         for i in range(batch_size):
             url = ""
             # Ensures a different backend endpoint gets picked each time
-            # 'ruby' /products /checkout endpoints not available yet
-            current_backend = backend(exclude='ruby')
+            current_backend = backend()
             ce = cexp()
             if (ce in [CExp.CHECKOUT_SUCCESS, CExp.PRODUCTS_BE_ERROR, CExp.PRODUCTS_EXTREMELY_SLOW] and current_backend != 'flask'):
                 # those two are only implemented for flask

--- a/tda/desktop_web/test_frontend_slowdown.py
+++ b/tda/desktop_web/test_frontend_slowdown.py
@@ -13,8 +13,7 @@ def test_frontend_slowdown(desktop_web_driver, endpoints, random, batch_size, ba
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                # 'ruby' /products /checkout endpoints not available yet
-                'backend': backend(exclude=['ruby', 'laravel', 'aspnetcore'])
+                'backend': backend(exclude=['laravel', 'aspnetcore'])
             }
             url = endpoint_frontend_slowdown + '?' + urlencode(query_string)
 

--- a/tda/desktop_web/test_products_join.py
+++ b/tda/desktop_web/test_products_join.py
@@ -13,8 +13,7 @@ def test_products_join(desktop_web_driver, endpoints, random, batch_size, backen
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                # 'ruby' /products /checkout endpoints not available yet
-                'backend': backend(exclude=['ruby', 'laravel', 'aspnetcore'])
+                'backend': backend(exclude=['laravel', 'aspnetcore'])
             }
             url = endpoint_products_join + '?' + urlencode(query_string)
 

--- a/tda/desktop_web/test_rageclick.py
+++ b/tda/desktop_web/test_rageclick.py
@@ -21,8 +21,7 @@ def test_rageclick(desktop_web_driver, endpoints, batch_size, backend, random, s
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                # 'ruby' /products /checkout endpoints not available yet
-                'backend': backend(exclude='ruby'),
+                'backend': backend(),
                 'rageclick': 'true'
             }
             url = endpoint_products + '?' + urlencode(query_string)


### PR DESCRIPTION
Previously we removed Ruby as `?backend=` option in TDA globally (https://github.com/sentry-demos/empower/pull/933) to get rid of some unintentional errors in `/about`

This cleans up all other tests that were excluding it already. Looks like it was also used in `test_homepage`. Pretty sure that was also not intentional

<img width="519" height="385" alt="Screenshot 2025-07-16 at 11 25 54 AM" src="https://github.com/user-attachments/assets/000173df-e089-4bc1-9762-7655a2ab1bfd" />
