### PR TITLE
[react] add ?api=join to use /products-join

### DIFF
--- a/react/src/components/Products.jsx
+++ b/react/src/components/Products.jsx
@@ -9,16 +9,20 @@ import ProductCard from './ProductCard';
 import { useState, useEffect } from 'react';
 import { updateStatsigUserAndEvaluate } from '../utils/statsig';
 
-function Products({ frontendSlowdown, backend, productsExtremelySlow, productsBeError, addToCartJsError }) {
+function Products({ frontendSlowdown, backend, productsApi, productsExtremelySlow, productsBeError, addToCartJsError }) {
   const [products, setProducts] = useState([]);
 
   function determineProductsEndpoint() {
-    if (productsExtremelySlow) {
-      return '/products?fetch_promotions=true';
-    } else if (productsBeError) {
-      return '/products?in_stock_only=1';
+    if (productsApi !== 'products-join') {
+      if (productsExtremelySlow) {
+        return '/products?fetch_promotions=true';
+      } else if (productsBeError) {
+        return '/products?in_stock_only=1';
+      } else {
+        return frontendSlowdown ? '/products-join' : '/products';
+      }
     } else {
-      return frontendSlowdown ? '/products-join' : '/products';
+      return '/products-join';
     }
   }
 

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -62,6 +62,7 @@ if (window.location.hostname === 'localhost') {
 let BACKEND_URL;
 let FRONTEND_SLOWDOWN;
 let RAGECLICK;
+let PRODUCTS_API;
 let PRODUCTS_EXTREMELY_SLOW;
 let PRODUCTS_BE_ERROR;
 let ADD_TO_CART_JS_ERROR;
@@ -233,6 +234,17 @@ class App extends Component {
       currentScope.setTag('frontendSlowdown', false);
     }
 
+    if (queryParams.get('api') === 'join') {
+      if (PRODUCTS_EXTREMELY_SLOW || PRODUCTS_BE_ERROR || FRONTEND_SLOWDOWN) {
+        throw new Error('?products_api=join can\'t be combined with ?cexp=products_extremely_slow, ?cexp=products_be_error, or ?frontendSlowdown=true');
+      }
+      PRODUCTS_API = 'products-join';
+      currentScope.setTag('api', 'products-join');
+    } else {
+      PRODUCTS_API = 'products';
+      currentScope.setTag('api', 'products');
+    }
+
     if (queryParams.get('rageclick') === 'true') {
       RAGECLICK = true;
     }
@@ -359,6 +371,7 @@ class App extends Component {
                 element={
                   <Products backend={BACKEND_URL}
                     frontendSlowdown={false}
+                    productsApi={PRODUCTS_API}
                     productsExtremelySlow={PRODUCTS_EXTREMELY_SLOW}
                     productsBeError={PRODUCTS_BE_ERROR}
                     addToCartJsError={ADD_TO_CART_JS_ERROR}


### PR DESCRIPTION
# Goal
Generate less of Slow DB Query and N+1 Issue spans so we can elevate `500 - Internal Server Error` to the top of Issue feed
TDA changes will follow. Basically some of the (non-CritExp) test flows will use /products-join and always error in checkout changing overall numbers.

# Related
https://github.com/sentry-demos/empower/pull/947

# Testing
`./deploy.sh --env=local react`

http://localhost:3000/?api=join&backend=flask -> click Products
http://localhost:3000/?api=join&backend=express -> click Products
http://localhost:3000/?api=join&backend=springboot -> click Products
http://localhost:3000/?api=join&backend=rails -> click Products
http://localhost:3000/?api=join&backend=aspnetcore -> click Products
http://localhost:3000/?api=join&backend=laravel -> click Products