### PR TITLE
[tda] elevate flagship by bypass CExp, re-attempt checkout, /products-join

### DIFF
--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -187,14 +187,22 @@ def sleep_length(random):
 @pytest.fixture
 def batch_size(random):
     if BATCH_SIZE.startswith("random_"):
-        return random.randrange(int(BATCH_SIZE.split('_')[1]))
+        parts = BATCH_SIZE.split('_')
+        if len(parts) == 2:
+            # random_X format: random number between 0 and X-1
+            return random.randrange(int(parts[1]))
+        elif len(parts) == 3:
+            # random_X_Y format: random number between X and Y (inclusive)
+            return random.randint(int(parts[1]), int(parts[2]))
+        else:
+            raise ValueError(f"Invalid BATCH_SIZE format: {BATCH_SIZE}. Expected 'random_X' or 'random_X_Y'")
     else:
         r = random.random() # unused, to make sure we call random same number of times
         return int(BATCH_SIZE)
 
 @pytest.fixture
 def backend(random):
-    def random_backend(exclude=[], include=[]):
+    def random_backend(exclude=[], include=[], probabilities=None):
         if not include:
             include = BACKENDS
         else:
@@ -213,9 +221,40 @@ def backend(random):
         #   >>> list(set(['b', 'a', 'f', 'd', 'e', 'c']) - set(['c', 'a']))
         #   ['d', 'f', 'b', 'e']
         backends = sorted(list(set(include) - set(exclude)))
-        if 'flask' in backends:
-            backends += ['flask'] # make flask 2x more likely than others
-        return random.sample(backends, 1)[0]
+        
+        if probabilities is not None:
+            # Validate that probabilities add up to 1.0
+            total_prob = sum(probabilities.values())
+            if abs(total_prob - 1.0) > 1e-6:  # Allow for small floating point errors
+                raise ValueError
+            
+            if not set(probabilities.keys()).issubset(set(backends)):
+                raise ValueError
+            
+            probs_to_use = probabilities
+        else:
+            # Default behavior: if flask is among backends, make it 2x more likely
+            if 'flask' in backends:
+                # Calculate default probabilities to make flask 2x more likely
+                num_backends = len(backends)
+                flask_weight = 2
+                other_weight = 1
+                total_weight = flask_weight + (num_backends - 1) * other_weight
+                
+                probs_to_use = {}
+                for backend_name in backends:
+                    if backend_name == 'flask':
+                        probs_to_use[backend_name] = flask_weight / total_weight
+                    else:
+                        probs_to_use[backend_name] = other_weight / total_weight
+            else:
+                # If flask not among backends, make all backends equally likely
+                return random.sample(backends, 1)[0]
+        
+        # Use weighted random choice
+        backend_names = list(probs_to_use.keys())
+        weights = list(probs_to_use.values())
+        return random.choices(backend_names, weights=weights, k=1)[0]
     return random_backend
 
 

--- a/tda/desktop_web/test_checkout.py
+++ b/tda/desktop_web/test_checkout.py
@@ -1,33 +1,53 @@
 import time
 import sentry_sdk
 from urllib.parse import urlencode
-from conftest import CExp
+from conftest import CExp, BACKENDS
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
 
 
+PRODUCTS_JOIN_RATIO = 0.5
+CEXP_RATIO = 0.3
+CHECKOUT_FLASK_RATIO = 0.6
+
 def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sleep_length, cexp):
     for endpoint in endpoints.react_endpoints:
-        endpoint_products = endpoint + "/products"
+
+        if random.random() < PRODUCTS_JOIN_RATIO:
+            endpoint_products = endpoint + "/products?api=join"
+        else:
+            endpoint_products = endpoint + "/products"
+
         sentry_sdk.set_tag("endpoint", endpoint_products)
         sentry_sdk.set_tag("batch_size", batch_size)
 
-        for i in range(batch_size):
+        for s in range(batch_size):
             url = ""
-            # Ensures a different backend endpoint gets picked each time
-            # 'ruby' /products /checkout endpoints not available yet
-            current_backend = backend(exclude='ruby')
-            ce = cexp()
-            if (ce in [CExp.CHECKOUT_SUCCESS, CExp.PRODUCTS_BE_ERROR, CExp.PRODUCTS_EXTREMELY_SLOW] and current_backend != 'flask'):
-                # those two are only implemented for flask
-                ce = CExp.STANDARD_CHECKOUT_FAIL
-            sentry_sdk.set_tag("cexp", ce)
+            
+            if random.random() < CEXP_RATIO: # Determine if this iteration should use CExp flow
+                current_backend = 'flask'
+                ce = cexp()
+                sentry_sdk.set_tag("cexp", ce)
+            else:
+                # For non-CExp flows, use CHECKOUT_FLASK_RATIO probabilities
+                ce = None
+                probs = {'flask': CHECKOUT_FLASK_RATIO}
+                for backend_name in BACKENDS:
+                    if backend_name != 'flask':
+                        probs[backend_name] = (1.0 - CHECKOUT_FLASK_RATIO) / (len(BACKENDS) - 1)
+                
+                current_backend = backend(probabilities=probs)
+            
+            # to generate more flagship errors than Slow DB Query, other performance issues
+            checkout_attempts = 1 if ce and ce in [CExp.CHECKOUT_SUCCESS, CExp.ADD_TO_CART_JS_ERROR] else 3
 
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
                 'backend': current_backend,
-                'cexp': ce
             }
+            if ce:
+                query_string['cexp'] = ce
+
             url = endpoint_products + '?' + urlencode(query_string)
             
             sentry_sdk.metrics.incr(key="test_checkout.iteration.started", value=1, tags=query_string)
@@ -54,25 +74,26 @@ def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sl
                 #   to solve for web vitals issue as transaction may not be resolving
                 time.sleep(2)
 
-                desktop_web_driver.find_element(By.CSS_SELECTOR, '.show-desktop #top-right-links a[href="/cart"]').click()
-
-                time.sleep(sleep_length())
-
-                if (ce != CExp.ADD_TO_CART_JS_ERROR):
-                    try:
-                        desktop_web_driver.find_element(By.CSS_SELECTOR, 'a[href="/checkout"]').click()
-                    except NoSuchElementException as err:
-                        sentry_sdk.metrics.incr(key="test_checkout.iteration.abandoned", value=1, tags=dict(query_string, reason="no_proceed_to_checkout_btn"))
-                        continue
+                for c in range(checkout_attempts):
+                    desktop_web_driver.find_element(By.CSS_SELECTOR, '.show-desktop #top-right-links a[href="/cart"]').click()
 
                     time.sleep(sleep_length())
-                    
-                    desktop_web_driver.find_element(By.CSS_SELECTOR, '#email').send_keys("sampleEmail@email.com")
 
-                    desktop_web_driver.find_element(By.CSS_SELECTOR, '.complete-checkout-btn').click()
-                    time.sleep(sleep_length())
+                    if (ce != CExp.ADD_TO_CART_JS_ERROR):
+                        try:
+                            desktop_web_driver.find_element(By.CSS_SELECTOR, 'a[href="/checkout"]').click()
+                        except NoSuchElementException as err:
+                            sentry_sdk.metrics.incr(key="test_checkout.iteration.abandoned", value=1, tags=dict(query_string, reason="no_proceed_to_checkout_btn"))
+                            continue
 
-                    sentry_sdk.metrics.incr(key="test_checkout.iteration.completed", value=1, tags=query_string)
+                        time.sleep(sleep_length())
+                        
+                        desktop_web_driver.find_element(By.CSS_SELECTOR, '#email').send_keys("sampleEmail@email.com")
+
+                        desktop_web_driver.find_element(By.CSS_SELECTOR, '.complete-checkout-btn').click()
+                        time.sleep(sleep_length())
+
+                        sentry_sdk.metrics.incr(key="test_checkout.iteration.completed", value=1, tags=query_string)
 
             except Exception as err:
                 sentry_sdk.metrics.incr(key="test_checkout.iteration.abandoned", value=1, tags=dict(query_string, reason=f"other({err.__class__.__name__})"))

--- a/tda/jobs/desktop_web.sh
+++ b/tda/jobs/desktop_web.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-BATCH_SIZE=random_20 pytest -s -n 7 --ignore-glob='*_vue.py' desktop_web
+# 0.0 - 0.3 cexp (flask) depening on cexp cycle
+# 0.7 non-cexp
+#   0.42-0.6 flask
+#   0.056-0.08 each of {express,springboot,laravel,rails,aspnetcore}
+# flask total = 0.6 - 0.72
+BATCH_SIZE=random_5_15 pytest -s -n 7 --ignore-glob='*_vue.py' desktop_web
+


### PR DESCRIPTION
# Goal
Make `500 - Internal Server Error` = flagship + Seer demo to show up at the top without needing to search for it 

# Solution
<img width="2800" height="2000" alt="checkout-flows-sankey-2" src="https://github.com/user-attachments/assets/ac584a4b-d6fc-4e2e-9bad-5a66b7f9d55f" />

[sankeymatic_20250718_120229_source.txt](https://github.com/user-attachments/files/21321848/sankeymatic_20250718_120229_source.txt)


# Testing
1. modify `desktop_web.sh` locally just for testing setting average `BATCH_SIZE=10` 
2. RUN_ID=tda-flask-flagship-bypass-cexp-AFTER ./jobs/desktop_web.sh
3. git reset --hard HEAD~1
4. modify `desktop_web.sh` locally just for testing setting average `BATCH_SIZE=10` 
5. RUN_ID=tda-flask-flagship-bypass-cexp-BEFORE ./jobs/desktop_web.sh

## AFTER
<img width="2704" height="3952" alt="elevate-flagshi-cexp-bypass-AFTER" src="https://github.com/user-attachments/assets/c6d8aa16-f3cd-454b-a4d1-27f111c0fc40" />

## BEFORE
<img width="3200" height="3208" alt="elevate-flagshi-cexp-bypass-BEFORE_2" src="https://github.com/user-attachments/assets/616f805b-bf63-4e01-b13b-a7788744d6b7" />


## CLI output
```
RUN_ID=tda-flask-flagship-bypass-cexp-AFTER ./jobs/desktop_web.sh
======================================================= test session starts =======================================================
platform darwin -- Python 3.13.3, pytest-7.4.2, pluggy-1.6.0
rootdir: /Users/kosty/home/emp4/tda
plugins: forked-1.4.0, xdist-3.1.0
gw0 [32] / gw1 [32] / gw2 [32] / gw3 [32] / gw4 [32] / gw5 [32] / gw6 [32]
................................
================================================= 32 passed in 639.76s (0:10:39) ==================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-tda_flask_flagship_bypass_cexp_AFTER%2A+%21project%3Aempower-tda&start=2025-07-18T18%3A20%3A01&end=2025-07-18T18%3A30%3A42
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-07-18T18%3A30%3A42&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-tda_flask_flagship_bypass_cexp_AFTER%2A&queryDataset=error-events&sort=-timestamp&start=2025-07-18T18%3A20%3A01&yAxis=count%28%29A
```

```
RUN_ID=tda-flask-flagship-bypass-cexp-BEFORE-2 ./jobs/desktop_web.sh
======================================================= test session starts =======================================================
platform darwin -- Python 3.13.3, pytest-7.4.2, pluggy-1.6.0
rootdir: /Users/kosty/home/emp4/tda
plugins: forked-1.4.0, xdist-3.1.0
gw0 [32] / gw1 [32] / gw2 [32] / gw3 [32] / gw4 [32] / gw5 [32] / gw6 [32]
................................
================================================= 32 passed in 576.14s (0:09:36) ==================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-tda_flask_flagship_bypass_cexp_BEFORE_2%2A+%21project%3Aempower-tda&start=2025-07-19T01%3A25%3A35&end=2025-07-19T01%3A35%3A12
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-07-19T01%3A35%3A12&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-tda_flask_flagship_bypass_cexp_BEFORE_2%2A&queryDataset=error-events&sort=-timestamp&start=2025-07-19T01%3A25%3A35&yAxis=count%28%29A
```