### PR TITLE
[tda] ssh through IAP tunnel, sleep 1 before hanging up

### DIFF
--- a/tda/build.sh
+++ b/tda/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e 
-#virtualenv --python=`which python3.8` env
 # old venv directory should already be removed by deploy_tda.sh
 python3.10 -m venv env
 source env/bin/activate 

--- a/tda/deploy_tda.sh
+++ b/tda/deploy_tda.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-HOST=empower-tda-and-crons.us-central1-a.sales-engineering-sf
+HOST=empower-tda-and-crons
+HOST_ZONE=us-central1-a
 DIR=/home/kosty/empower-tda
+GCP_PROJECT=sales-engineering-sf
+
+export CLOUDSDK_CORE_PROJECT=$GCP_PROJECT
+export CLOUDSDK_COMPUTE_ZONE=$HOST_ZONE
 
 function cleanup {
-  echo "NOTE: if ssh check hangs, re-run 'gcloud compute config-ssh; ssh $HOST exit' to fix"
+  echo "NOTE: if ssh check hangs, re-run 'gcloud compute config-ssh; gcloud compute ssh $HOST -- exit' to fix"
 }
 trap cleanup EXIT
 
 echo "Checking ssh connection can be established..."
-ssh -o StrictHostKeyChecking=accept-new $HOST exit
+gcloud compute ssh $HOST -- -o StrictHostKeyChecking=accept-new exit
 if [ $? != "0" ]; then
-  echo "[ERROR] Can't ssh into destination host. Please run 'gcloud compute config-ssh; ssh $HOST exit' to fix"
+  echo "[ERROR] Can't ssh into destination host. Please run 'gcloud compute config-ssh; gcloud compute ssh $HOST -- exit' to fix"
   exit 5 
 fi
 
@@ -19,6 +24,7 @@ trap - EXIT
 
 echo "Copying code to remote directory..."
 # for whatever reason can't delete or chmod __pycache__ directories
+export RSYNC_RSH='ssh -o "ProxyCommand gcloud compute start-iap-tunnel '$HOST' %p --listen-on-stdin --project='$GCP_PROJECT' --zone='$HOST_ZONE' --verbosity=warning"'
 rsync -rz --delete --force-delete --exclude env/ --exclude __pycache__ --exclude .pytest_cache * .sauce_credentials $HOST:$DIR/
 ret="$?"
 
@@ -34,7 +40,7 @@ fi
 echo "Code copied."
 
 echo "Copying logrotate configuration..."
-ssh $HOST 'sudo cp '$DIR'/logrotate.d/tda /etc/logrotate.d/tda && sudo sed -i "s/create 0640 replace_with_user replace_with_user/create 0640 $USER $USER/" /etc/logrotate.d/tda && sudo sed -i "s/su replace_with_user replace_with_user/su $USER $USER/" /etc/logrotate.d/tda'
+gcloud compute ssh $HOST -- 'sudo cp '$DIR'/logrotate.d/tda /etc/logrotate.d/tda && sudo sed -i "s/create 0640 replace_with_user replace_with_user/create 0640 $USER $USER/" /etc/logrotate.d/tda && sudo sed -i "s/su replace_with_user replace_with_user/su $USER $USER/" /etc/logrotate.d/tda'
 if [ $? != 0 ]; then
   echo "[ERROR] Failed to copy logrotate configuration to remote host."
   exit 1
@@ -42,7 +48,7 @@ fi
 echo "Logrotate configuration copied."
 
 echo "Testing logrotate configuration..."
-ssh $HOST 'sudo logrotate -d /etc/logrotate.d/tda'
+gcloud compute ssh $HOST -- 'sudo logrotate -d /etc/logrotate.d/tda'
 if [ $? != 0 ]; then
   echo "[ERROR] Logrotate configuration test failed."
   exit 1
@@ -50,8 +56,8 @@ fi
 echo "Logrotate configuration test passed."
 
 echo "Setting up log directory permissions..."
-ssh $HOST 'sudo mkdir -p /var/log && for job in '$DIR'/jobs/*.sh; do job_name=$(basename $job .sh); sudo touch /var/log/tda-$job_name.log; done && sudo chown $USER:$USER /var/log/tda*.log'
-ssh $HOST 'sudo touch /var/log/tda-signals.log && sudo chown $USER:$USER /var/log/tda-signals.log'
+gcloud compute ssh $HOST -- 'sudo mkdir -p /var/log && for job in '$DIR'/jobs/*.sh; do job_name=$(basename $job .sh); sudo touch /var/log/tda-$job_name.log; done && sudo chown $USER:$USER /var/log/tda*.log'
+gcloud compute ssh $HOST -- 'sudo touch /var/log/tda-signals.log && sudo chown $USER:$USER /var/log/tda-signals.log'
 if [ $? != 0 ]; then
   echo "[ERROR] Failed to set up log directory permissions."
   exit 1
@@ -59,10 +65,10 @@ fi
 echo "Log directory permissions set up."
 
 # setting permissions with rscync doesn't work, leaves 775 instead of 777 (umask?)
-ssh $HOST 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/empower-tda/env/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
+gcloud compute ssh $HOST -- 'find '$DIR' ! -path "*/__pycache__/*" ! -path "*/empower-tda/env/*" ! -path "*/canary.*" -exec sudo chmod 777 {} \;'
 
 echo "Cleaning up old virtual environment..."
-ssh $HOST 'sudo rm -rf '$DIR'/env'
+gcloud compute ssh $HOST -- 'sudo rm -rf '$DIR'/env'
 if [ $? != 0 ]; then
   echo "[ERROR] Failed to clean up old virtual environment."
   exit 1
@@ -70,8 +76,8 @@ fi
 echo "Old virtual environment cleaned up."
 
 echo "Installing requirements..."
-# Host must have python3.8 and virtualenv installed
-ssh $HOST 'cd '$DIR' && ./build.sh'
+# Host must have python3.12 and virtualenv installed
+gcloud compute ssh $HOST -- 'cd '$DIR' && ./build.sh'
 if [ $? != 0 ]; then
   echo "[ERROR] failed to install requirements on destination host"
   exit 1
@@ -82,10 +88,10 @@ set -e
 #       a situation where nothing is running
 # Side effect would be that then ./stop.sh would stop canaries as well - we don't want that
 echo Killing any currently running TDA processes...
-ssh $HOST 'cd '$DIR' && ./stop.sh'
+gcloud compute ssh $HOST -- 'cd '$DIR' && ./stop.sh'
 
 echo "Starting TDA..."
-ssh $HOST 'cd '$DIR' && ./run.sh'
+gcloud compute ssh $HOST -- 'cd '$DIR' && ./run.sh'
 if [ $? != 0 ]; then
   echo "[ERROR] failed to start TDA"
   exit 1

--- a/tda/run.sh
+++ b/tda/run.sh
@@ -30,3 +30,5 @@ for job in jobs/*.sh; do
   echo "Starting $job to run continuously in background..."
   nohup ./loop.sh ./$job >/var/log/tda-$job_name.log 2>&1 &
 done
+
+sleep 1 # give a chance for the background jobs to start


### PR DESCRIPTION
# Goals
1. IAP: that way don't have to open 22 to 0.0.0.0/0
2. mobile job (run last) may not start due to race condition if we end ssh session too quickly, this seems to have been the case most of the time after using IAP tunnel and/or switching to the new host

# Testing
`./deploy_tda.sh`