### PR TITLE
[tda] test_rageclick to use /products-join to create less perf issues

### DIFF
--- a/tda/desktop_web/test_rageclick.py
+++ b/tda/desktop_web/test_rageclick.py
@@ -21,6 +21,7 @@ def test_rageclick(desktop_web_driver, endpoints, batch_size, backend, random, s
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
+                'api': 'join', # faster, avoid generating too many N+1s, etc
                 'backend': backend(),
                 'rageclick': 'true'
             }


### PR DESCRIPTION
# Goals

- [primary] Elevate `500 - Internal Server Error` higher in the issue stream (see https://github.com/sentry-demos/empower/pull/955)
- runs faster

# Testing
```
RUN_ID=tda-test-rageclick-use-products-join-2 python3 -m pytest -s desktop_web/test_rageclick.py
======================================================= test session starts =======================================================
platform darwin -- Python 3.13.3, pytest-7.4.2, pluggy-1.6.0
rootdir: /Users/kosty/home/emp4/tda
plugins: forked-1.4.0, xdist-3.1.0
collected 4 items                                                                                                                 

desktop_web/test_rageclick.py SauceOnDemandSessionID=47541a4c4ab84f3f8b64e96950d986e3 job-name=test_rageclick[chrome_windows]
.SauceOnDemandSessionID=efee9ac10be8402f97c58cbfb72527b2 job-name=test_rageclick[fake_firefox_windows]
.SauceOnDemandSessionID=22b42a9f8b7f4a629d661a301543b9ed job-name=test_rageclick[chrome_windows_2]
.SauceOnDemandSessionID=1587a08c6a45499cb0bab2c16a351feb job-name=test_rageclick[chrome_osx]
.

================================================== 4 passed in 96.50s (0:01:36) ===================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-tda_test_rageclick_use_products_join_2%2A+%21project%3Aempower-tda&start=2025-07-22T02%3A35%3A04&end=2025-07-22T02%3A36%3A42
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-07-22T02%3A36%3A42&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-tda_test_rageclick_use_products_join_2%2A&queryDataset=error-events&sort=-timestamp&start=2025-07-22T02%3A35%3A04&yAxis=count%28%29A
```

## BEFORE
<img width="1141" height="298" alt="Screenshot 2025-07-21 at 7 35 40 PM" src="https://github.com/user-attachments/assets/9b9cf8ca-eb61-4903-8c0d-0c30b249f93f" />

## AFTER
<img width="1145" height="221" alt="Screenshot 2025-07-21 at 7 37 09 PM" src="https://github.com/user-attachments/assets/526b925e-98b8-4f56-82e0-619896e6f31b" />


