### PR TITLE
[react] split out flagship + backendType:flask into separate issue

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -60,6 +60,7 @@ if (window.location.hostname === 'localhost') {
 }
 
 let BACKEND_URL;
+let BACKEND_TYPE;
 let FRONTEND_SLOWDOWN;
 let RAGECLICK;
 let PRODUCTS_API;
@@ -140,6 +141,11 @@ Sentry.init({
       }
     }
 
+    if (BACKEND_TYPE === 'flask' && is5xxError && (se && se.startsWith('prod-tda-'))) {
+      // Seer when run automatically will use the latest event. We want it to run on event with flask backend instead of taking chances.
+      event.fingerprint += ['flagship-react-flask'];
+    }
+
     if (event.exception) {
       sessionStorage.setItem('lastErrorEventId', event.event_id);
     }
@@ -178,7 +184,8 @@ class App extends Component {
     // Set desired backend
     let backendTypeParam = queryParams.get('backend');
     const backendType = determineBackendType(backendTypeParam);
-    BACKEND_URL = determineBackendUrl(backendType, ENVIRONMENT);
+    BACKEND_TYPE = backendType;
+    BACKEND_URL = determineBackendUrl(backendType);
 
     console.log(`> backendType: ${backendType} | backendUrl: ${BACKEND_URL}`);
 


### PR DESCRIPTION
# Goal
Seer when run automatically will use the latest event. We want it to run on event using flask backend (for which we have increased TDA volume in https://github.com/sentry-demos/empower/pull/955) instead of taking chances with other backends where we haven't tested autofix performance.

Before this we had a Grouping rule accomplish this but it doesn't cover sandbox and can be accidentally removed.

# Testing
`./deploy.sh --env=local react`