### PR TITLE
[flask,tda] elevate react flagship above flask flagship

### DIFF
--- a/tda/desktop_web/test_checkout.py
+++ b/tda/desktop_web/test_checkout.py
@@ -99,4 +99,4 @@ def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sl
                 sentry_sdk.metrics.incr(key="test_checkout.iteration.abandoned", value=1, tags=dict(query_string, reason=f"other({err.__class__.__name__})"))
                 sentry_sdk.capture_exception(err)
 
-            time.sleep(sleep_length())
+            time.sleep(3)


### PR DESCRIPTION
# Goal

Currently `flask` flagship gets about 1% more events likely because some lost on the client side
This change aims to tip the balance just enough so that `500 - Internal Server Error` comes on top

<img width="889" height="404" alt="Screenshot 2025-07-24 at 3 57 34 PM" src="https://github.com/user-attachments/assets/d672faf1-37fb-4b64-a868-154e33a414f1" />
