### PR TITLE
[flask] clean working (after fix) checkout; [laravel] identical impl [react] include laravel in grouping

### DIFF
--- a/flask/.gcloudignore
+++ b/flask/.gcloudignore
@@ -21,6 +21,8 @@ __pycache__/
 
 env
 env/
+venv
+venv/
 
 .env.default
 

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -141,7 +141,7 @@ Sentry.init({
       }
     }
 
-    if (BACKEND_TYPE === 'flask' && is5xxError && (se && se.startsWith('prod-tda-'))) {
+    if ((BACKEND_TYPE === 'flask' || BACKEND_TYPE === 'laravel') && is5xxError && (se && se.startsWith('prod-tda-'))) {
       // Seer when run automatically will use the latest event. We want it to run on event with flask backend instead of taking chances.
       event.fingerprint += ['flagship-react-flask'];
     }


### PR DESCRIPTION
# Goals
1. Make `500 - Internal Server Error` come up **at the very top** (when sorted by Events at least)
2. Have a reasonably realistic flagship error in Laravel (currently contrived)
3. Have a Seer-fixable error in Laravel
4. Increase event volume of Laravel flagship so it shows up higher in the feed

# Implementation
- fixed flask inventory validation so that if the `quantities` initialization order fix is applied it actually works
- removed some junk in db.py
- replaced Laravel's current trivial implementation with one identical to Flask's, including the same kind of programming error
- changed custom fingerprint in React to include `backendType:laravel`

# Testing
```
./deploy.sh --env=staging laravel flask
```
https://staging-react.empower-plant.com/ (defaults to flask)
https://staging-react.empower-plant.com/?backend=laravel

For both:
1. went through standard checkout flow - got expected errors: [team-se/staging-flask](https://team-se.sentry.io/issues/6771070939/) and [team-se/staging-laravel](https://team-se.sentry.io/issues/6771061919/)
2. fixed `quantities` initialization order - got successful checkout (react doesn't handle partial stock or out of stock, shows success as long as it's HTTP 200) with expected response bodies depending on number of each product in the cart. E.g.
<img width="812" height="128" alt="Screenshot 2025-07-25 at 3 43 41 PM" src="https://github.com/user-attachments/assets/b21d51fa-d587-4180-bfe9-da9e7caf552f" />

3. [https://staging-react.empower-plant.com/?cexp=checkout_success](https://staging-react.empower-plant.com/?cexp=checkout_success) (aka `validate_inventory=false`) and got success.
