### PR TITLE
[tda,react] Add laravel as 'preferred' backend to CExp bypass flow

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -58,6 +58,8 @@ if (window.location.hostname === 'localhost') {
   // App Engine
   ENVIRONMENT = 'production';
 }
+    
+const PREFERRED_BACKENDS = ['flask', 'laravel'];
 
 let BACKEND_URL;
 let BACKEND_TYPE;
@@ -141,9 +143,9 @@ Sentry.init({
       }
     }
 
-    if ((BACKEND_TYPE === 'flask' || BACKEND_TYPE === 'laravel') && is5xxError && (se && se.startsWith('prod-tda-'))) {
+    if ((PREFERRED_BACKENDS.includes(BACKEND_TYPE)) && is5xxError && (se && se.startsWith('prod-tda-'))) {
       // Seer when run automatically will use the latest event. We want it to run on event with flask backend instead of taking chances.
-      event.fingerprint += ['flagship-react-flask'];
+      event.fingerprint += ['tda-flagship-react-preferred-backends'];
     }
 
     if (event.exception) {

--- a/tda/desktop_web/test_checkout.py
+++ b/tda/desktop_web/test_checkout.py
@@ -8,7 +8,8 @@ from selenium.common.exceptions import NoSuchElementException
 
 PRODUCTS_JOIN_RATIO = 0.5
 CEXP_RATIO = 0.3
-CHECKOUT_FLASK_RATIO = 0.6
+BYPASS_PREFERRED_BACKENDS_RATIO = 0.6 # backends that have a realistic autofixable error
+BYPASS_PREFERRED_BACKENDS = ['flask', 'laravel']
 
 def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sleep_length, cexp):
     for endpoint in endpoints.react_endpoints:
@@ -31,10 +32,13 @@ def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sl
             else:
                 # For non-CExp flows, use CHECKOUT_FLASK_RATIO probabilities
                 ce = None
-                probs = {'flask': CHECKOUT_FLASK_RATIO}
+                probs = {}
                 for backend_name in BACKENDS:
-                    if backend_name != 'flask':
-                        probs[backend_name] = (1.0 - CHECKOUT_FLASK_RATIO) / (len(BACKENDS) - 1)
+                    if backend_name in BYPASS_PREFERRED_BACKENDS:
+                        probs[backend_name] = BYPASS_PREFERRED_BACKENDS_RATIO / len(BYPASS_PREFERRED_BACKENDS)
+                    else:
+                        probs[backend_name] = (1.0 - BYPASS_PREFERRED_BACKENDS_RATIO) / (len(BACKENDS) - len(BYPASS_PREFERRED_BACKENDS))
+                    
                 
                 current_backend = backend(probabilities=probs)
             


### PR DESCRIPTION
# Goal

Elevate Laravel flagship relative to Laravel performance issues now that it's (reasonably) realistic and autofixable

# Related 
#955
#972
#962

# Testing

`./deploy.sh --env=local react` -> go through checkout flow, verify error in Sentry

```
RUN_ID=tda-add-laravel-to-cexp-bypass python3 -m pytest -s desktop_web/test_checkout.py
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.13.3, pytest-7.4.2, pluggy-1.6.0
rootdir: /Users/kosty/home/emp4/tda
plugins: forked-1.4.0, xdist-3.1.0
collected 4 items                                                                                                                                 

desktop_web/test_checkout.py SauceOnDemandSessionID=38a9b5580f2b412fb2b60c89b914ab0e job-name=test_checkout[chrome_windows]
.SauceOnDemandSessionID=51d11a7a97294356b0a71de188b35a48 job-name=test_checkout[fake_firefox_windows]
.SauceOnDemandSessionID=9d9daf522d1140ae9e679f07591f47e7 job-name=test_checkout[chrome_windows_2]
.SauceOnDemandSessionID=f09a7edd851949d0ac250a28f32d3782 job-name=test_checkout[chrome_osx]
.

========================================================== 4 passed in 127.88s (0:02:07) ==========================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-tda_add_laravel_to_cexp_bypass%2A+%21project%3Aempower-tda&start=2025-07-29T19%3A52%3A09&end=2025-07-29T19%3A54%3A18
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-07-29T19%3A54%3A18&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-tda_add_laravel_to_cexp_bypass%2A&queryDataset=error-events&sort=-timestamp&start=2025-07-29T19%3A52%3A09&yAxis=count%28%29A
```