### PR TITLE
[tda] test_basic_checkout for NextJS

### DIFF
--- a/next/src/ui/checkout/CheckoutForm.jsx
+++ b/next/src/ui/checkout/CheckoutForm.jsx
@@ -1,25 +1,44 @@
 'use client'
 
 import React, { useState } from 'react';
-import * as Sentry from '@sentry/nextjs';
 import { connect } from 'react-redux';
-import { ThreeDots } from 'react-loader-spinner';
 import ThreeDotLoader from '../ThreeDotLoader';
+import Cookies from 'js-cookie';
 
 
 export function CheckoutForm({ cart, checkoutAction }) {
   const [loading, setLoading] = useState(false);
-  const [form, setForm] = useState({
-    email: 'plant.lover@example.com',
-    subscribe: '',
-    firstName: 'Jane',
-    lastName: 'Greenthumb',
-    address: '123 Main Street',
-    city: 'San Francisco',
-    country: 'United States of America',
-    state: 'CA',
-    zipCode: '94122',
-  });
+  let initialFormValues;
+  const se = Cookies.get("se");
+  console.log("> se", se);
+  const seTdaPrefixRegex = /[^-]+-tda-[^-]+-/;
+  if (se && seTdaPrefixRegex.test(se)) {
+    // we want form actually filled out in TDA for a realistic-looking Replay
+    initialFormValues = {
+      email: '',
+      subscribe: '',
+      firstName: '',
+      lastName: '',
+      address: '',
+      city: '',
+      country: '',
+      state: '',
+      zipCode: '',
+    };
+  } else {
+    initialFormValues = {
+      email: 'plant.love@example.com',
+      subscribe: '',
+      firstName: 'Jane',
+      lastName: 'Greenthumb',
+      address: '123 Main Street',
+      city: 'San Francisco',
+      country: 'United States of America',
+      state: 'CA',
+      zipCode: '94122',
+    };
+  }
+  const [form, setForm] = useState(initialFormValues);
 
   function handleInputChange(event) {
     const target = event.target;

--- a/react/src/components/Checkout.jsx
+++ b/react/src/components/Checkout.jsx
@@ -44,7 +44,7 @@ function Checkout({ backend, rageclick, checkout_success, cart }) {
   const [form, setForm] = useState(initialFormValues);
 
 
-async function checkout(cart, checkout_span) {
+  async function checkout(cart, checkout_span) {
     console.log("Checkout called with cart:", cart);
     console.log("Checkout span:", checkout_span);
     const itemsInCart = countItemsInCart(cart);

--- a/tda/config.local.yaml
+++ b/tda/config.local.yaml
@@ -7,6 +7,4 @@ browsers:
 
 dsn: 'http://tda@localhost:9989/9'
 
-react_endpoints: [http://localhost:3000]
-
-vue_endpoints: []
+react_endpoint: http://localhost:3000

--- a/tda/config.yaml
+++ b/tda/config.yaml
@@ -34,8 +34,6 @@ browsers:
 dsn: 'https://9802de20229e4afdaa0d60796cbb44d7@o87286.ingest.sentry.io/5390094'
 
 # endpoints should NOT have "/" at the end
-react_endpoints:
-- https://empower-plant.com
-
-vue_endpoints:
-- https://application-monitoring-vue-dot-sales-engineering-sf.appspot.com
+react_endpoint: https://empower-plant.com
+nextjs_endpoint: https://nextjs.empower-plant.com
+vue_endpoint: https://application-monitoring-vue-dot-sales-engineering-sf.appspot.com

--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -76,8 +76,9 @@ class Config(NamedTuple):
     mode: str
     browsers: tuple[Browser, ...]
     dsn: str
-    react_endpoints: tuple[str, ...]
-    vue_endpoints: tuple[str, ...]
+    react_endpoint: str
+    nextjs_endpoint: str
+    vue_endpoint: str
 
 
 def _config() -> Config:
@@ -88,8 +89,9 @@ def _config() -> Config:
         mode=contents['mode'],
         browsers=tuple(Browser(**d) for d in contents['browsers']),
         dsn=contents['dsn'],
-        react_endpoints=tuple(contents['react_endpoints']),
-        vue_endpoints=tuple(contents['vue_endpoints']),
+        react_endpoint=contents['react_endpoint'],
+        nextjs_endpoint=contents['nextjs_endpoint'],
+        vue_endpoint=contents['vue_endpoint'],
     )
 
 CONFIG = _config()

--- a/tda/desktop_web/test_about_employees.py
+++ b/tda/desktop_web/test_about_employees.py
@@ -5,7 +5,8 @@ from urllib.parse import urlencode
 
 def test_about_employees(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
 
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
+
         endpoint_about = endpoint + "/about"
         sentry_sdk.set_tag("endpoint", endpoint_about)
 

--- a/tda/desktop_web/test_about_employees_vue.py
+++ b/tda/desktop_web/test_about_employees_vue.py
@@ -3,7 +3,7 @@ import sentry_sdk
 
 def test_about_employees_vue(desktop_web_driver, endpoints, random, batch_size, sleep_length):
 
-    for endpoint in endpoints.vue_endpoints:
+    for endpoint in [endpoints.vue_endpoint]:
 
         endpoint = endpoint + "/about"
 

--- a/tda/desktop_web/test_basic_checkout.py
+++ b/tda/desktop_web/test_basic_checkout.py
@@ -1,0 +1,60 @@
+import time
+import sentry_sdk
+from urllib.parse import urlencode
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+
+
+def test_basic_checkout(desktop_web_driver, endpoints, random, sleep_length, cexp):
+    for endpoint in [endpoints.nextjs_endpoint]:
+
+        endpoint_products = endpoint + "/products"
+
+        # to generate more flagship errors than Slow DB Query, other performance issues
+        checkout_attempts = 3
+
+        query_string = {}
+        url = endpoint_products + '?' + urlencode(query_string)
+        
+        # Buttons are not available if products didn't load before selection, so handle this
+        try:
+            desktop_web_driver.get(url)
+
+            try:
+                # Wait up to 2 implicit waits (should be 20 seconds)
+                try:
+                    add_to_cart_btn = desktop_web_driver.find_element(By.CSS_SELECTOR, '.products-list button')
+                except NoSuchElementException as err:
+                    add_to_cart_btn = desktop_web_driver.find_element(By.CSS_SELECTOR, '.products-list button')
+
+                for i in range(random.randrange(4) + 1):
+                    add_to_cart_btn.click()
+            except NoSuchElementException as err:
+                continue
+
+            # Add 2 second sleep between the initial /products pageload
+            #   and the navigation to the checkout cart
+            #   to solve for web vitals issue as transaction may not be resolving
+            time.sleep(2)
+
+            for c in range(checkout_attempts):
+                desktop_web_driver.find_element(By.CSS_SELECTOR, '.show-desktop #top-right-links a[href="/cart"]').click()
+
+                time.sleep(sleep_length())
+
+                try:
+                    desktop_web_driver.find_element(By.CSS_SELECTOR, 'a[href="/checkout"]').click()
+                except NoSuchElementException as err:
+                    continue
+
+                time.sleep(sleep_length())
+                
+                desktop_web_driver.find_element(By.CSS_SELECTOR, '#email').send_keys("sampleEmail@email.com")
+
+                desktop_web_driver.find_element(By.CSS_SELECTOR, '.complete-checkout-btn').click()
+                time.sleep(sleep_length())
+
+        except Exception as err:
+            sentry_sdk.capture_exception(err)
+
+        time.sleep(sleep_length())

--- a/tda/desktop_web/test_cexp_checkout.py
+++ b/tda/desktop_web/test_cexp_checkout.py
@@ -11,8 +11,8 @@ CEXP_RATIO = 0.3
 BYPASS_PREFERRED_BACKENDS_RATIO = 0.6 # backends that have a realistic autofixable error
 BYPASS_PREFERRED_BACKENDS = ['flask', 'laravel']
 
-def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sleep_length, cexp):
-    for endpoint in endpoints.react_endpoints:
+def test_cexp_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sleep_length, cexp):
+    for endpoint in [endpoints.react_endpoint]:
 
         if random.random() < PRODUCTS_JOIN_RATIO:
             endpoint_products = endpoint + "/products?api=join"

--- a/tda/desktop_web/test_frontend_slowdown.py
+++ b/tda/desktop_web/test_frontend_slowdown.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 
 def test_frontend_slowdown(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
 
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
         endpoint_frontend_slowdown = endpoint + "/products-fes"
         sentry_sdk.set_tag("endpoint", endpoint_frontend_slowdown)
 

--- a/tda/desktop_web/test_homepage.py
+++ b/tda/desktop_web/test_homepage.py
@@ -27,7 +27,7 @@ def test_homepage(desktop_web_driver, endpoints, random, batch_size, backend, sl
         upper_bound = .4
 
 
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
         sentry_sdk.set_tag("endpoint", endpoint)
 
         for i in range(batch_size):

--- a/tda/desktop_web/test_homepage_vue.py
+++ b/tda/desktop_web/test_homepage_vue.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 # Note: Not sure why won't pytest find this and run it when I name it 'vue_test_homepage'
 def test_homepage_vue(desktop_web_driver, endpoints, random, batch_size, sleep_length):
 
-    for endpoint in endpoints.vue_endpoints:
+    for endpoint in [endpoints.vue_endpoint]:
 
         # TODO homepage endpoint loads Products but in future will need to append /products to the endpoint
         sentry_sdk.set_tag("endpoint", endpoint)

--- a/tda/desktop_web/test_nplusone_api_call.py
+++ b/tda/desktop_web/test_nplusone_api_call.py
@@ -5,7 +5,7 @@ import sentry_sdk
 def test_nplusone_api_call(desktop_web_driver, endpoints, random, batch_size, sleep_length):
     sentry_sdk.set_tag("pytestName", "test_nplusone_api_call")
 
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
         endpoint_organization = endpoint + "/nplusone"
         sentry_sdk.set_tag("endpoint", endpoint_organization)
 

--- a/tda/desktop_web/test_organization.py
+++ b/tda/desktop_web/test_organization.py
@@ -9,7 +9,7 @@
 # def test_organization(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
 #     sentry_sdk.set_tag("pytestName", "test_organization")
 
-#     for endpoint in endpoints.react_endpoints:
+#     for endpoint in [endpoints.react_endpoint]:
 #         endpoint_organization = endpoint + "/organization"
 #         sentry_sdk.set_tag("endpoint", endpoint_organization)
 

--- a/tda/desktop_web/test_products_join.py
+++ b/tda/desktop_web/test_products_join.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 
 def test_products_join(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
 
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
         endpoint_products_join = endpoint + "/products-join"
         sentry_sdk.set_tag("endpoint", endpoint_products_join)
 

--- a/tda/desktop_web/test_rageclick.py
+++ b/tda/desktop_web/test_rageclick.py
@@ -10,7 +10,7 @@ RAGE_CLICK_TRIGGER_QTY = 10
 
 def test_rageclick(desktop_web_driver, endpoints, batch_size, backend, random, sleep_length):
 
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
         endpoint_products = endpoint + "/products"
         sentry_sdk.set_tag("endpoint", endpoint_products)
 

--- a/tda/desktop_web/test_subscribe.py
+++ b/tda/desktop_web/test_subscribe.py
@@ -11,7 +11,7 @@ def test_subscribe(desktop_web_driver, endpoints, batch_size, sleep_length, rand
     A standalone test that navigates to each React endpoint, attempts an email
     subscription, and records success/failure to Sentry metrics.
     """
-    for endpoint in endpoints.react_endpoints:
+    for endpoint in [endpoints.react_endpoint]:
         # Tag each test iteration with the endpoint
         sentry_sdk.set_tag("endpoint", endpoint)
 

--- a/tda/desktop_web/test_subscribe_vue.py
+++ b/tda/desktop_web/test_subscribe_vue.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 
 def test_subscribe_vue(desktop_web_driver, endpoints, random, batch_size, sleep_length):
 
-    for endpoint in endpoints.vue_endpoints:
+    for endpoint in [endpoints.vue_endpoint]:
         
         endpoint = endpoint + "/subscribe"
 


### PR DESCRIPTION
# Goal
Have fresh NextJS (and eventually Angular, Vue) events in Demo and Sandbox

# Testing

1. **TDA**
https://app.saucelabs.com/tests/7a6f49cccf884ab1b5c192abc05233bf (see failing form validation because form pre-filled)
```
RUN_ID=tda-nextjs python3 -m pytest -s -n 5 desktop_web
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.13.3, pytest-7.4.2, pluggy-1.6.0
rootdir: /Users/kosty/home/emp4/tda
plugins: forked-1.4.0, xdist-3.1.0
gw0 [48] / gw1 [48] / gw2 [48] / gw3 [48] / gw4 [48]
................................................
=============================================================== 48 passed in 393.58s (0:06:33) ================================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-tda_nextjs%2A+%21project%3Aempower-tda&start=2025-08-25T18%3A32%3A29&end=2025-08-25T18%3A39%3A04
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-08-25T18%3A39%3A04&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-tda_nextjs%2A&queryDataset=error-events&sort=-timestamp&start=2025-08-25T18%3A32%3A29&yAxis=count%28%29A
```

3. **NextJS**
`vercel dev` 
http://localhost:3000/products?se=prod-tda-direct--desktop_web/test_checkout.py-sauce-chrome_windows_2 -> form NOT pre-filled
http://localhost:3000/products?se=kosty -> form pre-filled

