### PR TITLE
[tda] add Flutter + cleanup

### DIFF
--- a/tda/conftest.py
+++ b/tda/conftest.py
@@ -144,13 +144,6 @@ _browser2class = {
     'safari': SafariOptions
 }
 
-def pytest_addoption(parser):
-    parser.addoption("--dc", action="store", default='us', help="Set Sauce Labs Data Center (US or EU)")
-
-@pytest.fixture
-def data_center(request):
-    return request.config.getoption('--dc')
-
 @pytest.fixture
 def random(request):
     if REPEATABLE_RANDOM:
@@ -353,15 +346,11 @@ class _ExtraParams:
 class RemoteWithExtraUrlParams(_ExtraParams, webdriver.Remote): pass
 class ChromeWithExtraUrlParams(_ExtraParams, webdriver.Chrome): pass
 
-@pytest.fixture
-def selenium_endpoint(data_center):
-    username = os.environ['SAUCE_USERNAME']
-    access_key = os.environ['SAUCE_ACCESS_KEY']
 
-    if data_center and data_center.lower() == 'eu':
-        return "https://{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
-    else:
-        return "https://{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
+SAUCE_USERNAME = os.environ['SAUCE_USERNAME']
+SAUCE_ACCESS_KEY = os.environ['SAUCE_ACCESS_KEY']
+SELENIUM_ENDPOINT = "https://ondemand.us-west-1.saucelabs.com/wd/hub"
+
 
 def sanitize_se_tag_component(c):
     if not c:
@@ -400,10 +389,9 @@ def se_prefix(request):
 
 
 @contextlib.contextmanager
-def _sauce_browser(request, selenium_endpoint, se):
+def _sauce_browser(request, se):
     try:
         test_name = request.node.name
-        build_tag = os.environ.get('BUILD_TAG', "Application-Monitoring-TDA")
 
         options = _browser2class[request.param.browserName]()
 
@@ -421,12 +409,13 @@ def _sauce_browser(request, selenium_endpoint, se):
             
         options.set_capability('sauce:options', {
             'seleniumVersion': '4.8.0',
-            'build': build_tag,
-            'name': test_name
+            'name': test_name,
+            'username': SAUCE_USERNAME,
+            'accessKey': SAUCE_ACCESS_KEY
         })
 
         browser = RemoteWithExtraUrlParams(
-            command_executor=selenium_endpoint,
+            command_executor=SELENIUM_ENDPOINT,
             options=options,
             keep_alive=True,
             # Note: these tags might not be supported by some frontends, e.g. Vue
@@ -492,7 +481,7 @@ def desktop_web_driver(request, se_prefix):
     if request.param.remote:
         se = f'{se_prefix}-sauce-{request.param.param_display}'
         sentry_sdk.set_tag("se", se)
-        with _sauce_browser(request, request.getfixturevalue('selenium_endpoint'), se) as b:
+        with _sauce_browser(request, se) as b:
             yield b
     else:
         se = f'{se_prefix}-local-{request.param.param_display}'
@@ -501,7 +490,7 @@ def desktop_web_driver(request, se_prefix):
             yield b
 
 @pytest.fixture
-def android_react_native_emu_driver(request, selenium_endpoint, se_prefix):
+def android_react_native_emu_driver(request, se_prefix):
 
     se = f'{se_prefix}-sauce-android10'
     sentry_sdk.set_tag('se', se)
@@ -516,13 +505,14 @@ def android_react_native_emu_driver(request, selenium_endpoint, se_prefix):
             'appium:automationName': 'uiautomator2',
             'sauce:options': {
                 'appiumVersion': '2.0.0',
-                'build': 'RDC-Android-Python-Best-Practice',
-                'name': request.node.name
+                'name': request.node.name,
+                'username': SAUCE_USERNAME,
+                'accessKey': SAUCE_ACCESS_KEY
             },
             'appWaitForLaunch': False
         })
 
-        driver = appiumdriver.Remote(selenium_endpoint, options=options)
+        driver = appiumdriver.Remote(SELENIUM_ENDPOINT, options=options)
         driver.implicitly_wait(20)
 
         sentry_sdk.set_tag("sauceLabsUrl", f"https://app.saucelabs.com/tests/{driver.session_id}")
@@ -539,7 +529,7 @@ def android_react_native_emu_driver(request, selenium_endpoint, se_prefix):
         sentry_sdk.capture_exception(err)
 
 @pytest.fixture
-def android_emu_driver(request, selenium_endpoint, se_prefix):
+def android_emu_driver(request, se_prefix):
 
     se = f'{se_prefix}-sauce-android10'
     sentry_sdk.set_tag('se', se)
@@ -553,13 +543,14 @@ def android_emu_driver(request, selenium_endpoint, se_prefix):
             'app': f'https://github.com/sentry-demos/android/releases/download/{release_version}/app-release.apk',
             'sauce:options': {
                 'appiumVersion': '2.0.0',
-                'build': 'RDC-Android-Python-Best-Practice',
-                'name': request.node.name
+                'name': request.node.name,
+                'username': SAUCE_USERNAME,
+                'accessKey': SAUCE_ACCESS_KEY
             },
             'appWaitForLaunch': False
         })
 
-        driver = appiumdriver.Remote(selenium_endpoint, options=options)
+        driver = appiumdriver.Remote(SELENIUM_ENDPOINT, options=options)
         driver.implicitly_wait(20)
 
         sentry_sdk.set_tag("sauceLabsUrl", f"https://app.saucelabs.com/tests/{driver.session_id}")
@@ -577,7 +568,7 @@ def android_emu_driver(request, selenium_endpoint, se_prefix):
         raise
 
 @pytest.fixture
-def ios_react_native_sim_driver(request, selenium_endpoint, se_prefix):
+def ios_react_native_sim_driver(request, se_prefix):
 
     se = f'{se_prefix}-sauce-ios15.5'
     sentry_sdk.set_tag('se', se)
@@ -591,13 +582,14 @@ def ios_react_native_sim_driver(request, selenium_endpoint, se_prefix):
 
             'sauce:options': {
                 'appiumVersion': '2.0.0',
-                'build': 'RDC-iOS-Python-Best-Practice',
                 'name': request.node.name,
+                'username': SAUCE_USERNAME,
+                'accessKey': SAUCE_ACCESS_KEY
             },
             'appium:app': f'https://github.com/sentry-demos/sentry_react_native/releases/download/{release_version}/sentry_react_native.app.zip',
         })
 
-        driver = appiumdriver.Remote(selenium_endpoint, options=options)
+        driver = appiumdriver.Remote(SELENIUM_ENDPOINT, options=options)
         driver.implicitly_wait(20)
 
         sentry_sdk.set_tag("sauceLabsUrl", f"https://app.saucelabs.com/tests/{driver.session_id}")
@@ -614,7 +606,7 @@ def ios_react_native_sim_driver(request, selenium_endpoint, se_prefix):
         sentry_sdk.capture_exception(err)
 
 @pytest.fixture
-def ios_sim_driver(request, selenium_endpoint, se_prefix):
+def ios_sim_driver(request, se_prefix):
 
     se = f'{se_prefix}-sauce-ios15.5'
     sentry_sdk.set_tag('se', se)
@@ -628,13 +620,14 @@ def ios_sim_driver(request, selenium_endpoint, se_prefix):
 
             'sauce:options': {
                 'appiumVersion': '1.22.3',
-                'build': 'RDC-iOS-Mobile-Native',
                 'name': request.node.name,
+                'username': SAUCE_USERNAME,
+                'accessKey': SAUCE_ACCESS_KEY
             },
             'appium:app': f'https://github.com/sentry-demos/ios/releases/download/{release_version}/EmpowerPlant_release.zip',
         })
 
-        driver = appiumdriver.Remote(selenium_endpoint, options=options)
+        driver = appiumdriver.Remote(SELENIUM_ENDPOINT, options=options)
         driver.implicitly_wait(20)
 
         sentry_sdk.set_tag("sauceLabsUrl", f"https://app.saucelabs.com/tests/{driver.session_id}")

--- a/tda/mobile_native/android_flutter/test_checkout_flutter_android.py
+++ b/tda/mobile_native/android_flutter/test_checkout_flutter_android.py
@@ -1,0 +1,25 @@
+import time
+import sentry_sdk
+from appium.webdriver.common.appiumby import AppiumBy
+
+def test_checkout_flutter_android(android_flutter_driver):
+
+    try:
+        # Add items to cart
+        add_to_cart_btn = android_flutter_driver.find_element(AppiumBy.ANDROID_UIAUTOMATOR, 'description("Add to cart")')
+        add_to_cart_btn.click()
+        add_to_cart_btn.click()
+        add_to_cart_btn.click()
+
+        # Checkout button
+        android_flutter_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Cart\nTab 2 of 2').click()
+        
+        android_flutter_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Proceed to checkout').click()
+        
+        android_flutter_driver.find_element(AppiumBy.ACCESSIBILITY_ID, 'Place your order').click()
+
+        # Sleep in seconds to allow time for both error and 'checkout' transaction to be sent
+        time.sleep(5)
+
+    except Exception as err:
+        sentry_sdk.capture_exception(err)


### PR DESCRIPTION
# Goal
- stream Flutter data to `demo` and `sandbox` (errors, spans, replays, logs, profiles).
- remove some legacy features in TDA

# Related
Using build based on latest updates by @Prithvirajkumar (no PR??) https://github.com/sentry-demos/flutter/commits/main/
Build has been uploaded as `1.0.0` - **next time when updating please just overwrite 1.0.0, no need to create new release**, creating new ones increases complexity with nothing to show for it atm

# Testing

```
RUN_ID=tda-flutter3 python3 -m pytest -s mobile_native/android_flutter/test_checkout_flutter_android.py
======================================================= test session starts =======================================================
platform darwin -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/kosty/home/emp4/tda
plugins: xdist-3.8.0, timeout-2.4.0, forked-1.6.0
collected 1 item                                                                                                                  

mobile_native/android_flutter/test_checkout_flutter_android.py .

================================================== 1 passed in 62.83s (0:01:02) ===================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-tda_flutter3%2A+%21project%3Aempower-tda&start=2025-08-26T22%3A59%3A50&end=2025-08-26T23%3A00%3A54
OWN errors:       https://demo.sentry.io/discover/results/?end=2025-08-26T23%3A00%3A54&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-tda_flutter3%2A&queryDataset=error-events&sort=-timestamp&start=2025-08-26T22%3A59%3A50&yAxis=count%28%29A
```
<img width="906" height="317" alt="Screenshot 2025-08-26 at 4 03 38 PM" src="https://github.com/user-attachments/assets/85780b4a-ffce-407f-bb1e-5b17352c2d2c" />

<img width="1165" height="680" alt="Screenshot 2025-08-26 at 4 04 05 PM" src="https://github.com/user-attachments/assets/492f70be-130c-4eff-864f-c3740a3bf073" />

<img width="932" height="614" alt="Screenshot 2025-08-26 at 4 04 58 PM" src="https://github.com/user-attachments/assets/2c9e9a77-b2fc-4d93-83d1-fcafb7277c85" />

<img width="627" height="636" alt="Screenshot 2025-08-26 at 4 05 18 PM" src="https://github.com/user-attachments/assets/83a9dd78-3aaa-48f3-9cf9-5e4646f7a605" />

<img width="691" height="366" alt="Screenshot 2025-08-26 at 4 03 14 PM" src="https://github.com/user-attachments/assets/5becd2f7-bb4b-417e-ac78-ad8b78ab20a4" />





