### PR TITLE
add cart total in failed and succesful checkout

### DIFF
--- a/react/src/components/Checkout.jsx
+++ b/react/src/components/Checkout.jsx
@@ -57,6 +57,7 @@ async function checkout(cart, checkout_span) {
 
     checkout_span.setAttribute("checkout.click", 1);
     checkout_span.setAttribute("items_at_checkout", itemsInCart);
+    checkout_span.setAttribute("checkout.order.total", cart.total);
 
     let tags = { 'backendType': getTag('backendType'), 'cexp': getTag('cexp'), 'items_at_checkout': itemsInCart, 'checkout.click': 1 };
     checkout_span.setAttributes(tags);
@@ -111,7 +112,6 @@ async function checkout(cart, checkout_span) {
       }
     } else {
       checkout_span.setAttribute("checkout.success", 1)
-      checkout_span.setAttribute("checkout.order.total", cart.total);
     }
 
     return response;


### PR DESCRIPTION
move `checkout.order.total` attribute declaration up so that it gets attached to events when checkout succeeds and fails. Currently, only gets attached if it succeeds. But it would be useful to have it to build widgets for "Total Revenue Lost" which seems to be a popular use case

<img width="1302" height="702" alt="Screenshot 2025-09-02 at 5 21 35 PM" src="https://github.com/user-attachments/assets/b3f5ce13-be2f-4fa5-93f8-3e320d56d3e8" />
