### PR TITLE
[tda] fix 1st run of the day to work with -n/numprocesses > 1

### DIFF
--- a/tda/jobs/desktop_web.sh
+++ b/tda/jobs/desktop_web.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+DAY_TRACKING_FILE="/tmp/tda_loop_prev_day"
+
+local current_day=$(date +%j)
+local prev_day=""
+if [ -f "$DAY_TRACKING_FILE" ]; then
+    prev_day=$(cat "$DAY_TRACKING_FILE" 2>/dev/null || echo "")
+fi
+if [ -z "$prev_day" ] || [ "$current_day" != "$prev_day" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [loop.sh] Day changed from '$prev_day' to '$current_day', setting IS_FIRST_RUN_OF_THE_DAY=1"
+    IS_FIRST_RUN_OF_THE_DAY=1 BATCH_SIZE=1 pytest --timeout=900 -s desktop_web/test_cexp_checkout.py &
+fi
+# Save current day number for next iteration
+echo "$current_day" > "$DAY_TRACKING_FILE" 2>/dev/null || true
+
 # timeout is per-test, test_checkout is batch so can potentially take quite long
 BATCH_SIZE=random_5_15 pytest --timeout=900 -s -n 7 --ignore-glob='*_vue.py' desktop_web
 

--- a/tda/loop.sh
+++ b/tda/loop.sh
@@ -52,35 +52,6 @@ trap 'log_signal "SIGIO" 29' IO
 trap 'log_signal "SIGPWR" 30' PWR
 trap 'log_signal "SIGSYS" 31' SYS
 
-# Day tracking file to persist the last day number
-DAY_TRACKING_FILE="/tmp/tda_loop_prev_day"
-
-# Function to get current day number
-get_current_day() {
-    date +%j
-}
-
-check_is_first_run_of_the_day() {
-    local current_day=$(get_current_day)
-    local prev_day=""
-    
-    # Read the previous day number from file if it exists
-    if [ -f "$DAY_TRACKING_FILE" ]; then
-        prev_day=$(cat "$DAY_TRACKING_FILE" 2>/dev/null || echo "")
-    fi
-    
-    # If this is the first run or day has changed, set IS_FIRST_RUN_OF_THE_DAY=1
-    if [ -z "$prev_day" ] || [ "$current_day" != "$prev_day" ]; then
-        export IS_FIRST_RUN_OF_THE_DAY=1
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [loop.sh] Day changed from '$prev_day' to '$current_day', setting IS_FIRST_RUN_OF_THE_DAY=1"
-    else
-        unset IS_FIRST_RUN_OF_THE_DAY
-    fi
-    
-    # Save current day number for next iteration
-    echo "$current_day" > "$DAY_TRACKING_FILE" 2>/dev/null || true
-}
-
 # Log script start
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] loop.sh started with PID $$, command: $*"
 


### PR DESCRIPTION
# Goal 
have 1 unique match for `user.email:John.Logs@example.com promo` query per 24 hours
previously IS_FIRST_RUN_OF_THE_DAY would be set for every forked process so each of the (typically) 4 processes running `test_cexp_checkout` would "think" it's the first one to run.

# Related
https://github.com/sentry-demos/empower/pull/1024