### PR TITLE
[tda] update selector for 'Add to Cart' button in iOS

### DIFF
--- a/_tda/mobile_native/ios/test_checkout_ios.py
+++ b/_tda/mobile_native/ios/test_checkout_ios.py
@@ -5,7 +5,7 @@ from appium.webdriver.common.appiumby import AppiumBy
 def test_checkout_ios(ios_sim_driver):
 
     try:
-        first_item = ios_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeApplication[@name="EmpowerPlant"]/XCUIElementTypeWindow/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeTable[1]/XCUIElementTypeCell[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther')
+        first_item = ios_sim_driver.find_element(AppiumBy.ACCESSIBILITY_ID, "AddToCart_Botana Voice")
         first_item.click()
         first_item.click()
         first_item.click()


### PR DESCRIPTION
# Goal

XPath selector has changed breaking TDA for iOS. @kpujjigit fixed in https://github.com/sentry-demos/ios/pull/140, updating _tda accordingly

# Testing
https://demo.sentry.io/issues/6396911541/events/d8541ce5544d43ccbe252895ece7291a/?query=

```
./deploy _tda --env=local -- ./run_local.sh mobile_native/ios/test_checkout_ios.py
[debug] Bash version: 3.2.57(1)-release
Google Cloud SDK 560.0.0
bq 2.1.29
core 2026.03.09
gcloud-crc32c 1.0.0
gsutil 5.36
Updates are available for some Google Cloud CLI components.  To install them,
please run:
  $ gcloud components update


To take a quick anonymous survey, run:
  $ gcloud survey

Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /opt/homebrew/Cellar/maven/3.9.12/libexec
Java version: 25.0.1, vendor: Homebrew, runtime: /opt/homebrew/Cellar/openjdk/25.0.1/libexec/openjdk.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "26.3.1", arch: "aarch64", family: "mac"
Composer version 2.9.3 2025-12-30 13:40:17
PHP version 8.3.30 (/opt/homebrew/Cellar/php@8.3/8.3.30/bin/php)
Run the "diagnose" command to get more detailed diagnostics output.
env = local
You are not authenticated with Google Cloud. Press any key to authenticate... (browser window may open)
Your browser has been opened to visit:

    https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=32555940559.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8085%2F&scope=openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fappengine.admin+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fsqlservice.login+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcompute+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Faccounts.reauth&state=qi2iBdoiEBNN5ashLxnfYyMeR7fcrv&access_type=offline&code_challenge=O3Gw05R1ETH1Pp9MtdWQvTXeOVW4PGNTMgmXSvLM2D0&code_challenge_method=S256


You are now logged in as [kosty.maleyev@sentry.io].
Your current project is [sales-engineering-sf].  You can change this setting by running:
  $ gcloud config set project PROJECT_ID


Updates are available for some Google Cloud CLI components.  To install them,
please run:
  $ gcloud components update

[environment: untagged] Read more https://cloud.google.com/resource-manager/docs/creating-managing-projects#designate_project_environments_with_tags.
Updated property [core/project].
|||
||| ./deploy: _tda
|||
Checking what env variables build.sh needs...
No references to GCP secrets found in build.sh
Checking what env variables run_local.sh needs...
No references to GCP secrets found in run_local.sh
Running build.sh with resolved environment...
Unable to symlink '/opt/homebrew/opt/python@3.12/bin/python3.12' to '/Users/kosty/home/emp2/_tda/env/bin/python3.12'
Requirement already satisfied: appium-python-client==5.1.1 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 7)) (5.1.1)
Requirement already satisfied: attrs==25.3.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 9)) (25.3.0)
Requirement already satisfied: certifi==2025.7.9 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 13)) (2025.7.9)
Requirement already satisfied: charset-normalizer==3.4.2 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 18)) (3.4.2)
Requirement already satisfied: execnet==2.1.1 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 20)) (2.1.1)
Requirement already satisfied: h11==0.16.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 22)) (0.16.0)
Requirement already satisfied: idna==3.10 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 24)) (3.10)
Requirement already satisfied: iniconfig==2.1.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 28)) (2.1.0)
Requirement already satisfied: outcome==1.3.0.post0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 30)) (1.3.0.post0)
Requirement already satisfied: packaging==25.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 34)) (25.0)
Requirement already satisfied: pluggy==1.6.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 36)) (1.6.0)
Requirement already satisfied: py==1.11.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 38)) (1.11.0)
Requirement already satisfied: pygments==2.19.2 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 40)) (2.19.2)
Requirement already satisfied: pysocks==1.7.1 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 42)) (1.7.1)
Requirement already satisfied: pytest==8.4.1 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 44)) (8.4.1)
Requirement already satisfied: pytest-forked==1.6.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 49)) (1.6.0)
Requirement already satisfied: pytest-timeout==2.4.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 51)) (2.4.0)
Requirement already satisfied: pytest-xdist==3.8.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 53)) (3.8.0)
Requirement already satisfied: pyyaml==6.0.2 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 55)) (6.0.2)
Requirement already satisfied: requests==2.32.4 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 57)) (2.32.4)
Requirement already satisfied: selenium==4.34.2 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 59)) (4.34.2)
Requirement already satisfied: sentry-sdk==2.32.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 63)) (2.32.0)
Requirement already satisfied: sniffio==1.3.1 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 65)) (1.3.1)
Requirement already satisfied: sortedcontainers==2.4.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 67)) (2.4.0)
Requirement already satisfied: trio==0.30.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 69)) (0.30.0)
Requirement already satisfied: trio-websocket==0.12.2 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 73)) (0.12.2)
Requirement already satisfied: typing-extensions==4.14.1 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 75)) (4.14.1)
Requirement already satisfied: urllib3==2.5.0 in ./env/lib/python3.12/site-packages (from urllib3[socks]==2.5.0->-r requirements.txt (line 77)) (2.5.0)
Requirement already satisfied: websocket-client==1.8.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 83)) (1.8.0)
Requirement already satisfied: wsproto==1.2.0 in ./env/lib/python3.12/site-packages (from -r requirements.txt (line 85)) (1.2.0)

[notice] A new release of pip is available: 25.3 -> 26.0.1
[notice] To update, run: pip install --upgrade pip
Running custom command './run_local.sh mobile_native/ios/test_checkout_ios.py ' with resolved environment...
[WARNING] we assume no secrets directly referenced by the custom command itself, any secrets used must be in *.template files
============================================================== test session starts ==============================================================
platform darwin -- Python 3.12.12, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/kosty/home/emp2/_tda
plugins: xdist-3.8.0, timeout-2.4.0, forked-1.6.0
collected 1 item                                                                                                                                

mobile_native/ios/test_checkout_ios.py Fetching ios release version from Github API...
.

========================================================= 1 passed in 131.01s (0:02:11) =========================================================

GENERATED errors: https://demo.sentry.io/issues/?query=se%3Akosty-tda-direct-%2A+%21project%3Aempower-tda&start=2026-04-02T18%3A11%3A01&end=2026-04-02T18%3A13%3A14
OWN errors:       https://demo.sentry.io/discover/results/?end=2026-04-02T18%3A13%3A14&field=title&field=se&field=sauceLabsUrl&field=cexp&field=timestamp&project=5390094&query=se%3Akosty-tda-direct-%2A&queryDataset=error-events&sort=-timestamp&start=2026-04-02T18%3A11%3A01&yAxis=count%28%29A
Sentry is attempting to send 2 pending events
Waiting up to 2 seconds
Press Ctrl-C to quit
Server process(es) are running. Press Ctrl+C to terminate...
All background processes have completed. Exiting...
Cleaning up...
```

