### PR TITLE
feat(react): add metrics instrumentation for dashboard demo

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "application-monitoring",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "~10.39.0",
+        "@sentry/react": "~10.47.0",
         "@statsig/js-client": "^3.15.0",
         "@testing-library/jest-dom": "~5.11.4",
         "@testing-library/react": "~11.1.0",
@@ -3977,50 +3977,50 @@
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.39.0.tgz",
-      "integrity": "sha512-W6WODonMGiI13Az5P7jd/m2lj/JpIyuVKg7wE4X+YdlMehLspAv6I7gRE4OBSumS14ZjdaYDpD/lwtnBwKAzcA==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.47.0.tgz",
+      "integrity": "sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.39.0"
+        "@sentry/core": "10.47.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.39.0.tgz",
-      "integrity": "sha512-cRXmmDeOr5FzVsBNRLU4WDEuC3fhuD0XV362EWl4DI3XBGao8ukaueKcLIKic5WZx6uXimjWw/UJmDLgxeCqkg==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.47.0.tgz",
+      "integrity": "sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.39.0"
+        "@sentry/core": "10.47.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.39.0.tgz",
-      "integrity": "sha512-obZoYOrUfxIYBHkmtPpItRdE38VuzF1VIxSgZ8Mbtq/9UvCWh+eOaVWU2stN/cVu1KYuYX0nQwBvdN28L6y/JA==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.47.0.tgz",
+      "integrity": "sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry-internal/browser-utils": "10.47.0",
+        "@sentry/core": "10.47.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.39.0.tgz",
-      "integrity": "sha512-TTiX0XWCcqTqFGJjEZYObk93j/sJmXcqPzcu0cN2mIkKnnaHDY3w74SHZCshKqIr0AOQdt1HDNa36s3TCdt0Jw==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.47.0.tgz",
+      "integrity": "sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry-internal/replay": "10.47.0",
+        "@sentry/core": "10.47.0"
       },
       "engines": {
         "node": ">=18"
@@ -4037,16 +4037,16 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.39.0.tgz",
-      "integrity": "sha512-I50W/1PDJWyqgNrGufGhBYCmmO3Bb159nx2Ut2bKoVveTfgH/hLEtDyW0kHo8Fu454mW+ukyXfU4L4s+kB9aaw==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.47.0.tgz",
+      "integrity": "sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.39.0",
-        "@sentry-internal/feedback": "10.39.0",
-        "@sentry-internal/replay": "10.39.0",
-        "@sentry-internal/replay-canvas": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry-internal/browser-utils": "10.47.0",
+        "@sentry-internal/feedback": "10.47.0",
+        "@sentry-internal/replay": "10.47.0",
+        "@sentry-internal/replay-canvas": "10.47.0",
+        "@sentry/core": "10.47.0"
       },
       "engines": {
         "node": ">=18"
@@ -4303,22 +4303,22 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.39.0.tgz",
-      "integrity": "sha512-xCLip2mBwCdRrvXHtVEULX0NffUTYZZBhEUGht0WFL+GNdNQ7gmBOGOczhZlrf2hgFFtDO0fs1xiP9bqq5orEQ==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
+      "integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.39.0.tgz",
-      "integrity": "sha512-qxReWHFhDcXNGEyAlYzhR7+K70es+vXaSknTZui1q7TfQwCT1rZlLKn/K8GDpNsb35RC5QhiIphU6pKbyYgZqw==",
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.47.0.tgz",
+      "integrity": "sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry/browser": "10.47.0",
+        "@sentry/core": "10.47.0"
       },
       "engines": {
         "node": ">=18"

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "~10.46.0",
+    "@sentry/react": "~10.47.0",
     "@statsig/js-client": "^3.15.0",
     "@testing-library/jest-dom": "~5.11.4",
     "@testing-library/react": "~11.1.0",

--- a/react/src/components/Cart.jsx
+++ b/react/src/components/Cart.jsx
@@ -42,14 +42,24 @@ function Cart({ cart, removeProduct, addProduct }) {
                   </p>
                   <div className="quantity-adjust">
                     <button
-                      onClick={() => removeProduct(item)}
+                      onClick={() => {
+                        removeProduct(item);
+                        Sentry.metrics.count('cart.remove', 1, {
+                          attributes: { product_id: item.id },
+                        });
+                      }}
                       className="sentry-unmask"
                     >
                       –
                     </button>
                     <span>{quantity}</span>
                     <button
-                      onClick={() => addProduct(item)}
+                      onClick={() => {
+                        addProduct(item);
+                        Sentry.metrics.count('cart.add', 1, {
+                          attributes: { source: 'cart', product_id: item.id },
+                        });
+                      }}
                       className="sentry-unmask"
                     >
                       +

--- a/react/src/components/ChatWidget.jsx
+++ b/react/src/components/ChatWidget.jsx
@@ -25,6 +25,7 @@ const ChatWidget = () => {
   const typingSpanRef = useRef(null);
   const typingTimeoutRef = useRef(null);
   const inactivityTimeoutRef = useRef(null);
+  const conversationStartedRef = useRef(false);
   const initTimeoutsRef = useRef([]);
 
   const scrollToBottom = () => {
@@ -231,7 +232,8 @@ const ChatWidget = () => {
     Sentry.metrics.count('chat.message_sent', 1, {
       attributes: { step: conversationState },
     });
-    if (conversationState === 'awaiting_light') {
+    if (conversationState === 'awaiting_light' && !conversationStartedRef.current) {
+      conversationStartedRef.current = true;
       Sentry.metrics.count('chat.conversation_started', 1);
     }
 
@@ -331,7 +333,7 @@ const ChatWidget = () => {
 
   const openChat = () => {
     Sentry.metrics.count('chat.open', 1);
-    // Opening the chat - start a new trace
+    conversationStartedRef.current = false;
     const conversationId = generateConversationId();
     conversationIdRef.current = conversationId;
     Sentry.setConversationId(conversationId);

--- a/react/src/components/ChatWidget.jsx
+++ b/react/src/components/ChatWidget.jsx
@@ -227,7 +227,14 @@ const ChatWidget = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!userInput.trim()) return;
-    
+
+    Sentry.metrics.count('chat.message_sent', 1, {
+      attributes: { step: conversationState },
+    });
+    if (conversationState === 'awaiting_light') {
+      Sentry.metrics.count('chat.conversation_started', 1);
+    }
+
     // Track the send click
     handleSendClick();
 
@@ -323,6 +330,7 @@ const ChatWidget = () => {
   };
 
   const openChat = () => {
+    Sentry.metrics.count('chat.open', 1);
     // Opening the chat - start a new trace
     const conversationId = generateConversationId();
     conversationIdRef.current = conversationId;

--- a/react/src/components/Product.jsx
+++ b/react/src/components/Product.jsx
@@ -34,7 +34,12 @@ function Product(props) {
         <p>{product.descriptionfull}</p>
         <button
           className="add-cart-btn"
-          onClick={() => props.addProduct(product)}
+          onClick={() => {
+            props.addProduct(product);
+            Sentry.metrics.count('cart.add', 1, {
+              attributes: { source: 'product_detail', product_id: product.id },
+            });
+          }}
         >
           <span className="sentry-unmask">Add to cart —</span> ${product.price}
           .00

--- a/react/src/components/ProductCard.jsx
+++ b/react/src/components/ProductCard.jsx
@@ -31,7 +31,12 @@ function ProductCard(props) {
           }
         }}
       >
-        <img src={product.img} alt="product" className="sentry-block" />
+        <img
+          src={product.img}
+          alt="product"
+          className="sentry-block"
+          elementtiming="product-card-image"
+        />
         <div>
           <h2>{product.title}</h2>
           <p className="product-description">{product.description}</p>
@@ -41,6 +46,9 @@ function ProductCard(props) {
           onClick={() => {
             if (validate_inventory(product)) {
               props.addProduct(product);
+              Sentry.metrics.count('cart.add', 1, {
+                attributes: { source: 'products_list', product_id: product.id },
+              });
             }
           }}
         >

--- a/react/src/components/Products.jsx
+++ b/react/src/components/Products.jsx
@@ -6,11 +6,13 @@ import { setProducts, addProduct } from '../actions';
 import measureRequestDuration from '../utils/measureRequestDuration';
 import Loader from 'react-loader-spinner';
 import ProductCard from './ProductCard';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { updateStatsigUserAndEvaluate } from '../utils/statsig';
 
 function Products({ frontendSlowdown, backend, productsApi, productsExtremelySlow, productsBeError, addToCartJsError }) {
   const [products, setProducts] = useState([]);
+  const startTime = useRef(performance.now());
+  const productsRendered = useRef(false);
 
   function determineProductsEndpoint() {
     if (productsApi !== 'products-join') {
@@ -128,6 +130,16 @@ function Products({ frontendSlowdown, backend, productsApi, productsExtremelySlo
       Sentry.captureException(error)
      }
   }, []);
+
+  useEffect(() => {
+    if (products.length > 0 && !productsRendered.current) {
+      productsRendered.current = true;
+      const duration = performance.now() - startTime.current;
+      Sentry.metrics.distribution('products.load_duration', duration, {
+        unit: 'millisecond',
+      });
+    }
+  }, [products]);
 
   return products.length > 0 ? (
     <div>

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -69,8 +69,6 @@ const ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT;
 console.log('ENVIRONMENT', ENVIRONMENT);
 console.log('RELEASE', RELEASE);
 
-
-
 Sentry.init({
   dsn: DSN,
   release: RELEASE,
@@ -91,7 +89,9 @@ Sentry.init({
   },
   integrations: (defaultIntegrations) => [
     // Filter out the Dedupe integration from the defaults
-    ...defaultIntegrations.filter(integration => integration.name !== "Dedupe"),
+    ...defaultIntegrations.filter(
+      (integration) => integration.name !== 'Dedupe'
+    ),
     // Add custom integrations with options
     Sentry.feedbackIntegration({
       // Additional SDK configuration goes in here, for example:
@@ -111,10 +111,11 @@ Sentry.init({
       blockAllMedia: false,
       // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details
       networkDetailAllowUrls: [/.*/],
-      unmask: [".sentry-unmask"],
+      unmask: ['.sentry-unmask'],
     }),
     Sentry.statsigIntegration({ featureFlagClient: statsigClient }),
     Sentry.consoleLoggingIntegration(), // All console logs are sent to Sentry
+    Sentry.elementTimingIntegration(),
   ],
   beforeSend(event, hint) {
     // Parse from tags because src/index.js already set it there. Once there are React route changes, it is no longer in the URL bar
@@ -123,7 +124,8 @@ Sentry.init({
       se = scope._tags.se;
     });
 
-    let is5xxError = event.exception && /^5\d{2} - .*$/.test(event.exception.values[0].value);
+    let is5xxError =
+      event.exception && /^5\d{2} - .*$/.test(event.exception.values[0].value);
     if (se && is5xxError) {
       // Create a separate issue for each SE and RELEASE combination
       const seTdaPrefixRegex = /[^-]+-tda-[^-]+-/;
@@ -201,7 +203,7 @@ class App extends Component {
     // recommended (https://docs.sentry.io/platforms/javascript/enriching-events/scopes/#isolation-scope),
     // because that would set the tag on the isolation scope, and make it inaccessible
     // when it's time to set the headers.
-    let currentScope = Sentry.getCurrentScope()
+    let currentScope = Sentry.getCurrentScope();
 
     const customerType = [
       'medium-plan',
@@ -221,7 +223,7 @@ class App extends Component {
     }
 
     // see `cexp` fixture in _tda/conftest.py
-    let cexp = queryParams.get('cexp')
+    let cexp = queryParams.get('cexp');
     if (cexp) {
       currentScope.setTag('cexp', cexp);
 
@@ -247,7 +249,9 @@ class App extends Component {
 
     if (queryParams.get('api') === 'join') {
       if (PRODUCTS_EXTREMELY_SLOW || PRODUCTS_BE_ERROR || FRONTEND_SLOWDOWN) {
-        throw new Error('?products_api=join can\'t be combined with ?cexp=products_extremely_slow, ?cexp=products_be_error, or ?frontendSlowdown=true');
+        throw new Error(
+          "?products_api=join can't be combined with ?cexp=products_extremely_slow, ?cexp=products_be_error, or ?frontendSlowdown=true"
+        );
       }
       PRODUCTS_API = 'products-join';
       currentScope.setTag('api', 'products-join');
@@ -282,10 +286,11 @@ class App extends Component {
       email = se + '@example.com';
     } else {
       const letters = 'abcdefghijklmnopqrstuvwxyz';
-      email = Array(3)
-        .fill()
-        .map(() => letters[Math.floor(Math.random() * letters.length)])
-        .join('') + '@example.com';
+      email =
+        Array(3)
+          .fill()
+          .map(() => letters[Math.floor(Math.random() * letters.length)])
+          .join('') + '@example.com';
     }
     currentScope.setUser({ email: email });
 
@@ -308,13 +313,24 @@ class App extends Component {
       if (!ignore_match) {
         Sentry.withScope(function (scope) {
           let se, customerType, email, cexp;
-          [se, customerType, email, cexp] = [scope._tags.se, scope._tags.customerType, scope._user.email, scope._tags.cexp];
-          args[1].headers = { ...args[1].headers, se, customerType, email, cexp };
+          [se, customerType, email, cexp] = [
+            scope._tags.se,
+            scope._tags.customerType,
+            scope._user.email,
+            scope._tags.cexp,
+          ];
+          args[1].headers = {
+            ...args[1].headers,
+            se,
+            customerType,
+            email,
+            cexp,
+          };
         });
       }
       let res = nativeFetch.apply(window, args);
-      if (args[0].includes('/apply-promo-code')) { 
-        await new Promise(resolve => setTimeout(resolve, 1500)); // to avoid log lines reordering due to clock drift between FE/BE
+      if (args[0].includes('/apply-promo-code')) {
+        await new Promise((resolve) => setTimeout(resolve, 1500)); // to avoid log lines reordering due to clock drift between FE/BE
       }
       return res;
     };
@@ -363,7 +379,8 @@ class App extends Component {
               <Route
                 path="/products"
                 element={
-                  <Products backend={BACKEND_URL}
+                  <Products
+                    backend={BACKEND_URL}
                     frontendSlowdown={false}
                     productsApi={PRODUCTS_API}
                     productsExtremelySlow={PRODUCTS_EXTREMELY_SLOW}


### PR DESCRIPTION
## Summary

Instruments the React frontend with Sentry custom metrics across four feature areas, feeding a new **Empower - Core Feature Metrics** dashboard ([demo.sentry.io/dashboard/4326879](https://demo.sentry.io/dashboard/4326879)).

### Cart engagement
- **`cart.add`** (counter) — emitted on every add-to-cart action with `source` attribute (`products_list`, `product_detail`, `cart`) and `product_id`. Covers all three call sites: `ProductCard.jsx`, `Product.jsx`, and the `+` button in `Cart.jsx`.
- **`cart.remove`** (counter) — emitted on the `–` button in `Cart.jsx` with `product_id`.

### Checkout funnel
No code changes — `checkout_submit.click`, `checkout_submit.success`, and `checkout_submit.error` already existed in `CheckoutForm.jsx`. Dashboard wired to the existing metrics.

### AI chat widget
- **`chat.open`** (counter) — fires in `openChat()` every time the user expands the widget.
- **`chat.conversation_started`** (counter) — fires once per session on the first user message (`conversationState === 'awaiting_light'`). Enables open→conversation conversion rate calculation.
- **`chat.message_sent`** (counter) — fires on every real user message with `step` attribute (`awaiting_light` or `awaiting_maintenance`) for Q1→Q2 step completion tracking.

### Frontend performance
- **`products.load_duration`** (distribution, ms) — measures time from `Products` component mount to products rendered, using `useRef` + `performance.now()`.
- **`elementtiming="product-card-image"`** on `ProductCard.jsx` `<img>` — paired with `Sentry.elementTimingIntegration()` (new in `@sentry/react` ~10.47.0) to emit `element_timing.render_time` and `element_timing.load_time` distribution metrics.

### SDK changes
- Bumps `@sentry/react` from ~10.46.0 to ~10.47.0 (required for `elementTimingIntegration`).
- Registers `Sentry.elementTimingIntegration()` in `index.js`.
- Minor formatting cleanup in `index.js` (no behavioral changes).

### Dashboard
A 24-widget dashboard was created via `sentry` CLI + API in the `demo` org with section headers, big-number KPIs, bar/line charts, and trend lines across all four areas. Dashboard ID: `4326879`.

## Test plan
- [ ] `npm start` from `empower/react`
- [ ] **Cart**: add items from `/products`, `/product/:id`, and cart `+`/`–` buttons → confirm `cart.add` and `cart.remove` appear in Sentry Metrics with correct `source` and `product_id` attributes
- [ ] **Checkout**: complete a checkout → confirm pre-existing `checkout_submit.*` metrics still fire
- [ ] **Chat**: open widget without sending → confirm `chat.open` only. Send first message → confirm `chat.conversation_started` + `chat.message_sent` with `step=awaiting_light`. Send second → confirm only `chat.message_sent` with `step=awaiting_maintenance`
- [ ] **Products perf**: load `/products` → confirm `products.load_duration` distribution appears
- [ ] **Element Timing**: load `/products` → confirm `element_timing.render_time` and `element_timing.load_time` appear for `product-card-image` identifier
- [ ] **Dashboard**: verify all widgets populate at https://demo.sentry.io/dashboard/4326879/

🤖 Generated with [Claude Code](https://claude.com/claude-code)