### PR TITLE
fix: promo code apply margin

### DIFF
--- a/react/src/components/CheckoutForm.jsx
+++ b/react/src/components/CheckoutForm.jsx
@@ -361,7 +361,6 @@ function CheckoutForm({ backend, rageclick, checkout_success, cart }) {
                   borderRadius: '4px',
                   cursor: promoLoading ? 'not-allowed' : 'pointer',
                   fontSize: '1.25rem',
-                  marginTop: '0px'
                 }}
               >
                 {promoLoading ? 'Applying...' : 'Apply'}


### PR DESCRIPTION
Button has a default margin of 8px
The "Apply" button has a margin top zero which makes the button and textbox to be mis-aligned vertically



Before
<img width="1314" height="171" alt="Screenshot 2026-05-06 at 7 37 52 PM" src="https://github.com/user-attachments/assets/c2cfa714-f01c-44e3-a0c3-b0f5afe578e7" />


After
<img width="637" height="82" alt="Screenshot 2026-05-06 at 7 38 08 PM" src="https://github.com/user-attachments/assets/3c44c9d8-5d1a-4b39-ad68-1f54bf8a6732" />
