### PR TITLE
fix: React Native TDA sleep

### DIFF
--- a/_tda/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
+++ b/_tda/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
@@ -13,5 +13,7 @@ def test_uncaughtthrownerror_react_native_ios(ios_react_native_sim_driver):
         # launch app again or the error does not get sent to Sentry
         ios_react_native_sim_driver.launch_app()
 
+        time.sleep(10) # replay success rate is ~ 75% for sleep >= 10 seconds and ~ 50% for sleep = 5 seconds
+
     except Exception as err:
         sentry_sdk.capture_exception(err)


### PR DESCRIPTION
**Summary**

- The React Native iOS test (uncaughtthrownerror_react_native_ios) isn't producing events in Sentry, while every other test in `_tda/mobile_native/ios_react_native/` works fine. 

**Problem**

- Unlike the in-session tests, a fatal JS error is flushed on the *next* app launch. The test currently opens the iOS app again, but there is no wait time. This might be the reason we do not see any data in Sentry.
- However that makes me wonder why the Android version of this test isnt producting error events either 🤔 

**Solution**

- Adding a 10s `time.sleep()` after `launch_app()` mirrors the existing pattern (and comment) in `test_uncaughtthrownerror_react_native_android.py`.

**Test plan**

- [ ] Run the test and confirm the event appears in Sentry