### PR TITLE
Add user and se Sentry tags to agent backend

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -3,11 +3,13 @@
 import os
 import sentry_sdk
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.openai import OpenAIIntegration
 from sentry_sdk.integrations.openai_agents import OpenAIAgentsIntegration
+from starlette.middleware.base import RequestResponseEndpoint
+from starlette.responses import Response
 
 from app.api.routes import router
 from config import settings
@@ -43,6 +45,32 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# Extract context information
+@app.middleware("http")
+async def sentry_event_context(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
+    se = request.headers.get("se")
+    customer_type = request.headers.get("customerType")
+    email = request.headers.get("email")
+    cexp = request.headers.get("cexp")
+
+    if se not in (None, "undefined"):
+        sentry_sdk.set_tag("se", se)
+
+    if customer_type not in (None, "undefined"):
+        sentry_sdk.set_tag("customerType", customer_type)
+
+    if email not in (None, "undefined"):
+        sentry_sdk.set_user({"email": email})
+
+    if cexp not in (None, "undefined"):
+        sentry_sdk.set_tag("cexp", cexp)
+
+    return await call_next(request)
+
 
 # Include API routes
 app.include_router(router, prefix="/api/v1", tags=["agent"])


### PR DESCRIPTION
Similar to flask project, grab the se, email, and customerType from the http headers and set them within the agent repo.

This unlocks the ability to query ai chats grouped by user email

Tested locally in custom test org

closes #1496 

Current
<img width="1359" height="666" alt="Screenshot 2026-05-28 at 3 29 19 PM" src="https://github.com/user-attachments/assets/d98cb173-0f70-4c63-acbf-0efdeae95bb2" />


New
<img width="1180" height="432" alt="Screenshot 2026-05-28 at 3 21 16 PM" src="https://github.com/user-attachments/assets/869c1775-464c-4401-b45c-eca3e2020226" />

<img width="1429" height="943" alt="Screenshot 2026-05-28 at 3 20 39 PM" src="https://github.com/user-attachments/assets/6c42c491-3b27-4f4f-a91c-969848b6a05b" />

