### PR TITLE
fix: use URL.create() for local DB connection to handle special chars in password

### DIFF
--- a/flask-otlp/src/db.py
+++ b/flask-otlp/src/db.py
@@ -26,7 +26,14 @@ class DatabaseConnectionError (Exception):
 
 if FLASKOTLP_ENVIRONMENT == "local":
     print("> ENVIRONMENT local ")
-    db = create_engine('postgresql://' + USERNAME + ':' + PASSWORD + '@' + HOST + ':5432/' + DATABASE)
+    db = create_engine(sqlalchemy.engine.url.URL.create(
+        drivername='postgresql',
+        username=USERNAME,
+        password=PASSWORD,
+        host=HOST,
+        port=5432,
+        database=DATABASE
+    ))
 else:
     CLOUD_SQL_CONNECTION_NAME = os.environ["DB_CLOUD_SQL_CONNECTION_NAME"]
     print("> ENVIRONMENT production ")

--- a/flask/src/db.py
+++ b/flask/src/db.py
@@ -22,7 +22,14 @@ class DatabaseConnectionError (Exception):
 
 if FLASK_ENVIRONMENT == "local":
     print("> ENVIRONMENT local ")
-    db = create_engine('postgresql://' + USERNAME + ':' + PASSWORD + '@' + HOST + ':5432/' + DATABASE)
+    db = create_engine(sqlalchemy.engine.url.URL.create(
+        drivername='postgresql',
+        username=USERNAME,
+        password=PASSWORD,
+        host=HOST,
+        port=5432,
+        database=DATABASE
+    ))
 else:
     CLOUD_SQL_CONNECTION_NAME = os.environ["DB_CLOUD_SQL_CONNECTION_NAME"]
     print("> ENVIRONMENT production ")


### PR DESCRIPTION
## Summary
- `flask/src/db.py` and `flask-otlp/src/db.py` used string concatenation to build the PostgreSQL connection URL locally
- Passwords containing special characters like `@` caused SQLAlchemy to misparse the hostname
- Fixed by using `sqlalchemy.engine.url.URL.create()` which handles encoding correctly

## Why this only affects local
The staging/production code path already uses `sqlalchemy.engine.url.URL(...)` (passing password as a Python argument), so special characters were never an issue there.

## Test plan
- [ ] Run `./deploy --env=local flask-otlp` and verify `/products` returns data
- [ ] Run `./deploy --env=local flask` and verify `/products` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)