### PR TITLE
Add demo-error query params + propagate se/user tags to agent spans

### DIFF
--- a/_tda/desktop_web/test_ai_agent.py
+++ b/_tda/desktop_web/test_ai_agent.py
@@ -9,6 +9,9 @@ VOLUME_FACTOR = 0.185 # reduce token usage
 WAIT_BEFORE_CLOSE_SECONDS = 80  # Allow time for Sentry trace capture
 BASE_ITERATIONS = 3
 JITTER_PERCENT = 30
+# Fraction of chat interactions that exercise each failing plant lookup.
+PLANT_ADVICE_FAILURE_RATE = 0.2
+PLANT_INFO_FAILURE_RATE = 0.1
 
 LIGHT_OPTIONS = ["low light", "medium light", "full sun"]
 MAINTENANCE_OPTIONS = ["yes", "no"]
@@ -55,6 +58,17 @@ def get_random_inputs() -> tuple[str, str]:
 
 
 def run_single_chat_interaction(driver, url: str, light: str, maintenance: str, iteration: int):
+    # Trigger each failing plant lookup for a fraction of interactions. These are
+    # the operator-facing flags the ChatWidget maps to the agent's domain params.
+    failure_params = []
+    if random.random() < PLANT_ADVICE_FAILURE_RATE:
+        failure_params.append("agent_advice_error=true")
+    if random.random() < PLANT_INFO_FAILURE_RATE:
+        failure_params.append("agent_info_error=true")
+    for param in failure_params:
+        separator = "&" if "?" in url else "?"
+        url = f"{url}{separator}{param}"
+
     driver.get(url)
     time.sleep(3)
     

--- a/agent/app/api/routes.py
+++ b/agent/app/api/routes.py
@@ -5,6 +5,7 @@ import sentry_sdk.ai
 from fastapi import APIRouter, HTTPException, Request
 
 from ..agents.manager_agent import process_user_request
+from ..utils import agent_crash_mode
 from .models import ChatResponse, HealthResponse, PlantPurchaseRequest
 
 # Initialize router
@@ -36,6 +37,13 @@ async def buy_plants(
     conversation_id = raw_request.headers.get("x-conversation-id")
     if conversation_id:
         sentry_sdk.ai.set_conversation_id(conversation_id)
+
+    # ?agent_crash=true forces the plant advice error every time; =false
+    # suppresses all injected errors; absent falls back to random probabilities.
+    agent_crash = raw_request.query_params.get("agent_crash")
+    agent_crash_mode.set(
+        None if agent_crash is None else agent_crash.lower() == "true"
+    )
 
     try:
         response = await process_user_request(

--- a/agent/app/api/routes.py
+++ b/agent/app/api/routes.py
@@ -5,7 +5,7 @@ import sentry_sdk.ai
 from fastapi import APIRouter, HTTPException, Request
 
 from ..agents.manager_agent import process_user_request
-from ..utils import agent_crash_mode
+from ..utils import validate_plant_advice, validate_plant_info
 from .models import ChatResponse, HealthResponse, PlantPurchaseRequest
 
 # Initialize router
@@ -38,11 +38,14 @@ async def buy_plants(
     if conversation_id:
         sentry_sdk.ai.set_conversation_id(conversation_id)
 
-    # ?agent_crash=true forces the plant advice error every time; =false
-    # suppresses all injected errors; absent falls back to random probabilities.
-    agent_crash = raw_request.query_params.get("agent_crash")
-    agent_crash_mode.set(
-        None if agent_crash is None else agent_crash.lower() == "true"
+    # ?validate_plant_advice=true makes the plant advice lookup fail;
+    # ?validate_plant_info=true makes the plant basic info lookup fail.
+    # Unset/anything else is false (no failure).
+    validate_plant_advice.set(
+        raw_request.query_params.get("validate_plant_advice", "").lower() == "true"
+    )
+    validate_plant_info.set(
+        raw_request.query_params.get("validate_plant_info", "").lower() == "true"
     )
 
     try:

--- a/agent/app/tools/plant_base_info.py
+++ b/agent/app/tools/plant_base_info.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from agents import FunctionTool
 
-from ..utils import agent_crash_mode, maybe_throw
+from ..utils import validate_plant_advice, validate_plant_info
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
@@ -38,7 +38,8 @@ def get_plant_basic_info(plant_names: list) -> str:
         },
     }
 
-    maybe_throw(0.1, Exception("Could not get plant basic info: Unknown plant"))
+    if validate_plant_info.get():
+        raise Exception("Could not get plant basic info: Unknown plant")
 
     # Collect info for each plant
     info_list = []
@@ -64,9 +65,8 @@ async def _invoke_plant_advice(context: Any, input_json: str) -> str:
     """Invoke the plant advice tool."""
     import json
 
-    if agent_crash_mode.get() is True:
+    if validate_plant_advice.get():
         raise Exception("Could not get plant advice: File not found")
-    maybe_throw(0.2, Exception("Could not get plant advice: File not found"))
 
     try:
         logging.debug(f"Invoking get_plant_basic_info with input: {input_json}")

--- a/agent/app/tools/plant_base_info.py
+++ b/agent/app/tools/plant_base_info.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from agents import FunctionTool
 
-from ..utils import maybe_throw
+from ..utils import agent_crash_mode, maybe_throw
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
@@ -64,6 +64,8 @@ async def _invoke_plant_advice(context: Any, input_json: str) -> str:
     """Invoke the plant advice tool."""
     import json
 
+    if agent_crash_mode.get() is True:
+        raise Exception("Could not get plant advice: File not found")
     maybe_throw(0.2, Exception("Could not get plant advice: File not found"))
 
     try:

--- a/agent/app/utils.py
+++ b/agent/app/utils.py
@@ -1,6 +1,21 @@
+import contextvars
 import random
+from typing import Optional
+
+# Controls the demo error injection via the ?agent_crash query param. Tri-state:
+#   True  -> force the plant advice error 100% of the time
+#   False -> suppress all injected errors (never crash)
+#   None  -> no override; fall back to the default random probabilities
+# Set in the API route and read inside the tool, which is invoked by the agents
+# SDK; a contextvar propagates through the awaited async chain.
+agent_crash_mode: contextvars.ContextVar[Optional[bool]] = contextvars.ContextVar(
+    "agent_crash_mode", default=None
+)
 
 
 def maybe_throw(probability: float, exception: Exception) -> None:
+    # An explicit ?agent_crash=false disables injected errors entirely.
+    if agent_crash_mode.get() is False:
+        return
     if random.random() < probability:
         raise exception

--- a/agent/app/utils.py
+++ b/agent/app/utils.py
@@ -1,21 +1,15 @@
 import contextvars
-import random
-from typing import Optional
 
-# Controls the demo error injection via the ?agent_crash query param. Tri-state:
-#   True  -> force the plant advice error 100% of the time
-#   False -> suppress all injected errors (never crash)
-#   None  -> no override; fall back to the default random probabilities
-# Set in the API route and read inside the tool, which is invoked by the agents
-# SDK; a contextvar propagates through the awaited async chain.
-agent_crash_mode: contextvars.ContextVar[Optional[bool]] = contextvars.ContextVar(
-    "agent_crash_mode", default=None
+# Set from query params on the /buy-plants request. When true, the corresponding
+# plant lookup fails, surfacing a demo error. Unset means false. Set in the API
+# route and read inside the tool, which is invoked by the agents SDK; a contextvar
+# propagates through the awaited async chain.
+#
+#   validate_plant_advice -> plant advice lookup fails (File not found)
+#   validate_plant_info   -> plant basic info lookup fails (Unknown plant)
+validate_plant_advice: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "validate_plant_advice", default=False
 )
-
-
-def maybe_throw(probability: float, exception: Exception) -> None:
-    # An explicit ?agent_crash=false disables injected errors entirely.
-    if agent_crash_mode.get() is False:
-        return
-    if random.random() < probability:
-        raise exception
+validate_plant_info: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "validate_plant_info", default=False
+)

--- a/agent/main.py
+++ b/agent/main.py
@@ -14,6 +14,38 @@ from starlette.responses import Response
 from app.api.routes import router
 from config import settings
 
+
+def propagate_context_to_spans(event, hint):
+    """Copy request-context tags onto every span's attributes.
+
+    The sentry_event_context middleware sets `se`/`customerType`/`cexp` as
+    event-level tags (and `email` as the user), which only land on the root
+    http.server span. The auto-instrumented gen_ai.* child spans don't inherit
+    them, so we mirror the values onto each span's `data` here.
+    """
+    tags = event.get("tags") or {}
+    attrs = {
+        key: tags[key]
+        for key in ("se", "customerType", "cexp")
+        if tags.get(key) is not None
+    }
+    email = (event.get("user") or {}).get("email")
+    if email is not None:
+        attrs["user.email"] = email
+
+    if not attrs:
+        return event
+
+    for span in event.get("spans", []):
+        span.setdefault("data", {}).update(attrs)
+
+    trace = (event.get("contexts") or {}).get("trace")
+    if trace is not None:
+        trace.setdefault("data", {}).update(attrs)
+
+    return event
+
+
 sentry_sdk.init(
     dsn=os.environ["AGENT_DSN"],
     environment=os.environ["AGENT_SENTRY_ENVIRONMENT"],
@@ -25,6 +57,7 @@ sentry_sdk.init(
     ],
     disabled_integrations=[OpenAIIntegration()],
     send_default_pii=True,
+    before_send_transaction=propagate_context_to_spans,
 )
 
 

--- a/react/src/components/ChatWidget.jsx
+++ b/react/src/components/ChatWidget.jsx
@@ -280,9 +280,17 @@ const ChatWidget = () => {
           requestHeaders['x-conversation-id'] = conversationIdRef.current;
         }
 
+        // Forward the agent_crash query param from the page URL to the agent
+        // so the backend can force the plant advice error on demand.
+        let buyPlantsUrl = `${AGENT_URL}/api/v1/buy-plants`;
+        const agentCrash = new URLSearchParams(window.location.search).get('agent_crash');
+        if (agentCrash) {
+          buyPlantsUrl += `?agent_crash=${encodeURIComponent(agentCrash)}`;
+        }
+
         if (chatSpanRef.current) {
           await Sentry.withActiveSpan(chatSpanRef.current, async () => {
-            response = await fetch(`${AGENT_URL}/api/v1/buy-plants`, {
+            response = await fetch(buyPlantsUrl, {
               method: 'POST',
               headers: requestHeaders,
               body: JSON.stringify({
@@ -293,7 +301,7 @@ const ChatWidget = () => {
             data = await response.json();
           });
         } else {
-          response = await fetch(`${AGENT_URL}/api/v1/buy-plants`, {
+          response = await fetch(buyPlantsUrl, {
             method: 'POST',
             headers: requestHeaders,
             body: JSON.stringify({

--- a/react/src/components/ChatWidget.jsx
+++ b/react/src/components/ChatWidget.jsx
@@ -280,12 +280,24 @@ const ChatWidget = () => {
           requestHeaders['x-conversation-id'] = conversationIdRef.current;
         }
 
-        // Forward the agent_crash query param from the page URL to the agent
-        // so the backend can force the plant advice error on demand.
+        // Map operator-facing error flags from the page URL to the agent's
+        // domain-named params, so the demo error triggers don't stand out in the
+        // agent's span attributes. agent_advice_error -> validate_plant_advice
+        // (hard 500), agent_info_error -> validate_plant_info (soft lookup error).
         let buyPlantsUrl = `${AGENT_URL}/api/v1/buy-plants`;
-        const agentCrash = new URLSearchParams(window.location.search).get('agent_crash');
-        if (agentCrash) {
-          buyPlantsUrl += `?agent_crash=${encodeURIComponent(agentCrash)}`;
+        const pageParams = new URLSearchParams(window.location.search);
+        const buyPlantsParams = new URLSearchParams();
+        const agentAdviceError = pageParams.get('agent_advice_error');
+        if (agentAdviceError) {
+          buyPlantsParams.set('validate_plant_advice', agentAdviceError);
+        }
+        const agentInfoError = pageParams.get('agent_info_error');
+        if (agentInfoError) {
+          buyPlantsParams.set('validate_plant_info', agentInfoError);
+        }
+        const buyPlantsQuery = buyPlantsParams.toString();
+        if (buyPlantsQuery) {
+          buyPlantsUrl += `?${buyPlantsQuery}`;
         }
 
         if (chatSpanRef.current) {


### PR DESCRIPTION
## Summary

Adds explicit, deterministic query-param control over the plant agent's demo errors (replacing the in-agent random injection), forwards operator-facing flags from the web app, and propagates request-context tags (`se`, `customerType`, `cexp`, `user.email`) onto every span in the agent trace.

### Demo error params

The agent fails specific plant lookups only when explicitly told — no random self-injection. The **backend** params are domain-named so the trigger doesn't stand out in Sentry span / attribute comparison; the **web app** exposes friendlier operator flags that map to them.

| Operator flag (page URL) | Forwarded to agent as | Behavior |
|--------------------------|-----------------------|----------|
| `?agent_advice_error=true` | `validate_plant_advice` | Hard **500** — `Could not get plant advice: File not found` |
| `?agent_info_error=true` | `validate_plant_info` | Soft tool error — `Could not get plant basic info: Unknown plant` |

Unset / anything else = false (no failure).

The ambient randomness for synthetic traffic now lives in the **TDA test**, which sets the flags at `PLANT_ADVICE_FAILURE_RATE = 0.2` and `PLANT_INFO_FAILURE_RATE = 0.1` — so real users never hit injected errors, only synthetic traffic does.

- `agent/app/utils.py` — two plain `bool` contextvars (`validate_plant_advice`, `validate_plant_info`); removed `maybe_throw` / random injection.
- `agent/app/api/routes.py` — parses both query params.
- `agent/app/tools/plant_base_info.py` — raises on the explicit flags instead of random throws.
- `react/src/components/ChatWidget.jsx` — maps `agent_advice_error` → `validate_plant_advice` and `agent_info_error` → `validate_plant_info` onto the `/buy-plants` request.
- `_tda/desktop_web/test_ai_agent.py` — drives the failure rates (0.2 / 0.1) via the operator flags.

### Propagate context tags onto gen_ai spans

`sentry_sdk.set_tag("se", ...)` only lands on the root `http.server` span, so the auto-instrumented `gen_ai.*` child spans didn't carry `se`. Added a `before_send_transaction` hook (`agent/main.py`) that mirrors `se` / `customerType` / `cexp` / `user.email` onto every span's `data` and the trace root.

## Testing

Verified locally (react :3000, agent :8093, flask :8083 via `./deploy --env=local`):
- `?agent_advice_error=true` → forces the 500 when the LLM routes through the plant-advice tool.
- Agent honors `validate_plant_advice` / `validate_plant_info` directly.
- `before_send_transaction` confirmed to copy the tags onto child `gen_ai.*` spans.

> Note: the agent only errors when the LLM (gpt-5-mini) actually routes through the relevant tool, so it isn't perfectly deterministic per request — the flags control how often the failure is attempted, and the TDA test exercises them across many iterations.

## Addressed review feedback
- Removed in-agent random error injection; randomness now lives in the TDA test (per review).
- Domain-named the backend params so the trigger doesn't break the 4th wall in attribute comparison.
- Simplified the contextvar to a plain `bool` (unset = false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
