### PR TITLE
react: continue incoming distributed trace from URL params (Web View handoff)

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -69,6 +69,39 @@ const ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT;
 console.log('ENVIRONMENT', ENVIRONMENT);
 console.log('RELEASE', RELEASE);
 
+// Distributed tracing handoff: when this app is opened from another Sentry SDK
+// (e.g. the Flutter app's in-app Web View), the upstream trace is passed via the
+// `sentry-trace` / `baggage` URL query params. The browser SDK continues a trace
+// from <meta name="sentry-trace"> / <meta name="baggage"> tags, so we promote the
+// params to meta tags BEFORE Sentry.init runs. This makes the React pageload a
+// child of the upstream trace, and the existing tracePropagationTargets carry the
+// same trace on to the backend — yielding one Flutter → React → backend trace.
+(function continueIncomingTrace() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const sentryTrace = params.get('sentry-trace');
+    if (!sentryTrace) return;
+    const baggage = params.get('baggage');
+
+    const upsertMeta = (name, content) => {
+      if (!content) return;
+      let meta = document.querySelector(`meta[name="${name}"]`);
+      if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', name);
+        document.head.appendChild(meta);
+      }
+      meta.setAttribute('content', content);
+    };
+
+    upsertMeta('sentry-trace', sentryTrace);
+    upsertMeta('baggage', baggage);
+    console.log('> continuing incoming trace from URL:', sentryTrace);
+  } catch (e) {
+    console.warn('Failed to continue incoming trace from URL params', e);
+  }
+})();
+
 Sentry.init({
   dsn: DSN,
   release: RELEASE,


### PR DESCRIPTION
## Summary

Lets the React app **continue an incoming distributed trace** that is handed to it via URL query params, so it can be the downstream of another Sentry SDK.

The concrete use case: the **Empower Plant Flutter app** opens this React app inside an in-app **Web View**. The Flutter SDK starts a trace and passes `sentry-trace` / `baggage` on the URL. Today the React app ignores them and starts a brand-new `pageload` trace, so the two are disconnected. With this change the React `pageload` **continues the upstream trace**, and the app's existing `tracePropagationTargets` carry that same trace on to the backend — giving **one** Flutter → React → backend distributed trace.

## What changed
`react/src/index.js` — a small IIFE added **before** `Sentry.init`:
- Reads `sentry-trace` (and `baggage`) from `window.location.search`.
- If `sentry-trace` is present, promotes them to `<meta name="sentry-trace">` / `<meta name="baggage">` tags in `document.head`.
- The browser SDK's `browserTracingIntegration` already natively reads those meta tags at init, so the `pageload` span continues the upstream trace.

```js
const params = new URLSearchParams(window.location.search);
const sentryTrace = params.get('sentry-trace');
if (!sentryTrace) return;            // no-op when absent
// → inject <meta name="sentry-trace"> / <meta name="baggage"> before Sentry.init
```

## Why this approach
The browser SDK can only continue a trace from `<meta>` tags (or an explicit API), **not** from HTTP request headers — JS can't read the document's request headers. Passing the trace on the URL and promoting it to meta tags before init is the minimal, idiomatic way to do the handoff. It mirrors how the app already reads other URL params (e.g. `?backend=`).

## Impact on existing instrumentation — none unless the param is present
- **No `sentry-trace` param (every normal page load / existing TDA runs / real users):** the function early-returns. Nothing is injected; pageload/navigation transactions, errors, Session Replay, profiling, logs, `?backend=` routing, and `tracePropagationTargets` all behave exactly as before.
- **`sentry-trace` present (opened from the Flutter Web View):** only the **pageload** transaction continues the upstream trace (different trace id + parent). No integration is disabled or altered; errors/replay/profiling/backend propagation keep working, just attributed to the continued trace. Sampling honors the upstream sampled flag (correct head-based distributed-tracing behavior).
- Fully wrapped in `try/catch` and runs before `Sentry.init`, so it can never break initialization or the app. It only *adds* meta tags (CRA's static `index.html` has none).

## Testing / verification
Verified locally end-to-end with the Flutter app pointed at a local build of this React app:
- React console logged `> continuing incoming trace from URL: <trace>-<span>-1`.
- The React `pageload` adopted the upstream trace id; the propagated `baggage` carried `sentry-transaction=webview/empower-plant` (the Flutter transaction).
- The page's backend calls (`/products`, `/organization`) rode on the same trace → one connected Flutter → React → flask trace.

## Notes
- The companion Flutter change (passing `sentry-trace`/`baggage` on the Web View URL) is in `sentry-demos/flutter` (PR #23).
- The `console.log` on a successful handoff is intentionally consistent with the file's existing debug logging; happy to gate/remove it if preferred.
- Minor: a crafted URL could make a pageload join an arbitrary trace id — irrelevant for this demo, noted for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
