### PR TITLE
tda(android_flutter): add Web View + OTLP journey tests

### DIFF
--- a/_tda/mobile_native/android_flutter/test_otlp_flutter_android.py
+++ b/_tda/mobile_native/android_flutter/test_otlp_flutter_android.py
@@ -68,7 +68,7 @@ def test_otlp_flutter_android(android_flutter_driver):
             ).send_keys("Broken")
 
             android_flutter_driver.find_element(
-                AppiumBy.ANDROID_UIAUTOMATOR, 'text("Send")'
+                AppiumBy.ACCESSIBILITY_ID, "Send"
             ).click()
         except Exception:
             pass  # Dialog only appears on checkout failure; safe to skip if absent

--- a/_tda/mobile_native/android_flutter/test_otlp_flutter_android.py
+++ b/_tda/mobile_native/android_flutter/test_otlp_flutter_android.py
@@ -1,0 +1,82 @@
+import time
+
+import sentry_sdk
+from appium.webdriver.common.appiumby import AppiumBy
+
+
+def test_otlp_flutter_android(android_flutter_driver):
+    """OTLP journey: opens the home page but routes all backend calls
+    (/products, /checkout) to the OpenTelemetry-instrumented backend
+    (flask-otlp), as its own new trace. Exercises both the product fetch and
+    a checkout so the trace continues into the OTLP backend.
+    """
+    try:
+        # ------------------------------------------------------------------
+        # Open the drawer and start the OTLP journey
+        # ------------------------------------------------------------------
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Open navigation menu"
+        ).click()
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "OTLP"
+        ).click()
+
+        # The OTLP home now loads products from the flask-otlp backend.
+        # ------------------------------------------------------------------
+        # Add items to cart
+        # ------------------------------------------------------------------
+        add_to_cart_btn = android_flutter_driver.find_element(
+            AppiumBy.ANDROID_UIAUTOMATOR, 'description("Add to cart")'
+        )
+        add_to_cart_btn.click()
+        add_to_cart_btn.click()
+        add_to_cart_btn.click()
+
+        # ------------------------------------------------------------------
+        # Navigate to the cart tab, then proceed to checkout (flask-otlp)
+        # ------------------------------------------------------------------
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Cart\nTab 2 of 2"
+        ).click()
+
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Proceed to checkout"
+        ).click()
+
+        # ------------------------------------------------------------------
+        # Place the order — POSTs to the OTLP backend's /checkout
+        # ------------------------------------------------------------------
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Place your order"
+        ).click()
+
+        # ------------------------------------------------------------------
+        # User feedback dialog — appears when the checkout request fails.
+        # Reduce the implicit wait so we don't block for 20 s on a
+        # successful checkout where no dialog is shown.
+        # ------------------------------------------------------------------
+        android_flutter_driver.implicitly_wait(5)
+        try:
+            android_flutter_driver.find_element(
+                AppiumBy.ANDROID_UIAUTOMATOR,
+                'className("android.widget.EditText").instance(0)',
+            ).send_keys("John")
+
+            android_flutter_driver.find_element(
+                AppiumBy.ANDROID_UIAUTOMATOR,
+                'className("android.widget.EditText").instance(1)',
+            ).send_keys("Broken")
+
+            android_flutter_driver.find_element(
+                AppiumBy.ANDROID_UIAUTOMATOR, 'text("Send")'
+            ).click()
+        except Exception:
+            pass  # Dialog only appears on checkout failure; safe to skip if absent
+        finally:
+            android_flutter_driver.implicitly_wait(20)
+
+        # Allow time for the OTLP checkout transaction/trace to be sent to Sentry
+        time.sleep(5)
+
+    except Exception as err:
+        sentry_sdk.capture_exception(err)

--- a/_tda/mobile_native/android_flutter/test_webview_flutter_android.py
+++ b/_tda/mobile_native/android_flutter/test_webview_flutter_android.py
@@ -1,0 +1,38 @@
+import time
+
+import sentry_sdk
+from appium.webdriver.common.appiumby import AppiumBy
+
+# Seconds to let the in-app WebView load the page and for the Flutter-side
+# WebView transaction + propagated trace headers to reach Sentry.
+_WEBVIEW_LOAD_WAIT_SECONDS = 8
+
+
+def test_webview_flutter_android(android_flutter_driver):
+    """Web View journey: opens empower-plant.com inside the app's in-app WebView.
+
+    This starts a dedicated transaction on a fresh trace and attaches the
+    sentry-trace/baggage so the loaded web page can continue the trace
+    (Flutter -> WebView distributed tracing).
+    """
+    try:
+        # ------------------------------------------------------------------
+        # Open the drawer and launch the Web View
+        # ------------------------------------------------------------------
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Open navigation menu"
+        ).click()
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Web View"
+        ).click()
+
+        # Confirm the Web View screen opened (its app bar title).
+        android_flutter_driver.find_element(
+            AppiumBy.ACCESSIBILITY_ID, "Empower Plant (Web)"
+        )
+
+        # Allow the page to load and the WebView transaction/trace to be sent.
+        time.sleep(_WEBVIEW_LOAD_WAIT_SECONDS)
+
+    except Exception as err:
+        sentry_sdk.capture_exception(err)


### PR DESCRIPTION
## Summary

Adds two `android_flutter` TDA tests covering the new **Web View** and **OTLP** journeys in the Empower Plant Flutter app, matching the existing test style (`android_flutter_driver` fixture, `AppiumBy` selectors, `try/except sentry_sdk.capture_exception`).

## New tests
`_tda/mobile_native/android_flutter/`:

### `test_webview_flutter_android.py`
Drives the **Web View** journey: opens the drawer → taps **Web View** → asserts the `Empower Plant (Web)` screen opened → waits for the page to load and for the Flutter `webview/empower-plant` transaction + propagated trace to reach Sentry. Exercises the new trace + the Flutter→web distributed-tracing handoff.

### `test_otlp_flutter_android.py`
Drives the **OTLP** journey end-to-end: drawer → **OTLP** → product list loads from the OpenTelemetry backend (`flask-otlp.empower-plant.com`) → add to cart → Cart tab → Proceed to checkout → Place your order → handles the failure feedback dialog. Generates a new trace whose `/products` and `/checkout` spans hit the OTLP backend (mirrors `test_checkout_flutter_android.py` but via the OTLP entry point).

## Selectors used (all verified against the current app)
`Open navigation menu`, `Web View`, `OTLP`, `Empower Plant (Web)`, `description("Add to cart")`, `Cart\nTab 2 of 2`, `Proceed to checkout`, `Place your order`, plus the feedback-dialog `EditText`s / `Send`. pytest auto-discovers the files — no registration needed.

## Validation
Ran both locally against the dev build via a local Appium server + UiAutomator2 (the repo fixture is Sauce-only). Both passed, and cross-checked beyond the pass (these tests intentionally swallow exceptions):
- **Web View:** Appium log showed `Open navigation menu` → `Web View` → `Empower Plant (Web)` located; the React `/products` page rendered in the web view.
- **OTLP:** zero no-such-element errors across the whole flow; device logs confirmed requests to `flask-otlp.empower-plant.com/products` and `/checkout`.

## Dependency / rollout note
These run on Sauce Labs against the **released** APK (`android_flutter_driver` → `github.com/sentry-demos/flutter/releases/.../flutter-android.apk`). The Web View and OTLP drawer items ship in `sentry-demos/flutter` PR #23, so these two tests will go green once a Flutter release **including those features** is published. Until then they collect (and, by the suite's `capture_exception` design, won't hard-fail the run) — the selectors are confirmed correct against the current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
