### PR TITLE
fix: bind chat widget metrics to chat session trace

### DIFF
--- a/react/src/components/ChatWidget.jsx
+++ b/react/src/components/ChatWidget.jsx
@@ -229,13 +229,16 @@ const ChatWidget = () => {
     e.preventDefault();
     if (!userInput.trim()) return;
 
-    Sentry.metrics.count('chat.message_sent', 1, {
-      attributes: { step: conversationState },
+    Sentry.withActiveSpan(chatSpanRef.current, () => {
+      Sentry.logger.info("Chat message sent")
+      Sentry.metrics.count('chat.message_sent', 1, {
+        attributes: { step: conversationState },
+      });
+      if (conversationState === 'awaiting_light' && !conversationStartedRef.current) {
+        conversationStartedRef.current = true;
+        Sentry.metrics.count('chat.conversation_started', 1);
+      }
     });
-    if (conversationState === 'awaiting_light' && !conversationStartedRef.current) {
-      conversationStartedRef.current = true;
-      Sentry.metrics.count('chat.conversation_started', 1);
-    }
 
     // Track the send click
     handleSendClick();
@@ -352,7 +355,6 @@ const ChatWidget = () => {
   };
 
   const openChat = () => {
-    Sentry.metrics.count('chat.open', 1);
     conversationStartedRef.current = false;
     const conversationId = generateConversationId();
     conversationIdRef.current = conversationId;
@@ -364,6 +366,8 @@ const ChatWidget = () => {
         forceTransaction: true,
       });
       chatSpanRef.current = span;
+      Sentry.logger.info('Chat session started');
+      Sentry.metrics.count('chat.open', 1);
     });
     setIsOpen(true);
   };


### PR DESCRIPTION
## Summary

Chat widget metrics and logs are being attributed to the **previous page trace** instead of the chat session trace

<img width="762" height="409" alt="Monosnap Trace Details - 11f93e961bbb4…0a5f20f1f38b — demo — Sentry 2026-06-22 09-22-37" src="https://github.com/user-attachments/assets/6820e3f5-8091-4ed0-8a5d-d1d629debc20" />
<img width="1526" height="878" alt="Monosnap Trace Details - 0c856fa592a14…2e1f4f6be2a0 — demo — Sentry 2026-06-22 09-21-53" src="https://github.com/user-attachments/assets/9250cd8c-6e0a-43e8-85e5-4200fee214ab" />


## Changes

- Move metrics and logs into the chat sessions trace
- Now, all chat sessions will have logs/metrics. This creates an easy transition to the "connected data model" talk

<img width="468" height="56" alt="Screenshot 2026-06-18 at 3 45 03 PM" src="https://github.com/user-attachments/assets/89361a49-df96-49b2-9ed4-ea86516d64ea" />
