### PR TITLE
docs: add AGENTS.md for empower root and _tda

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md — Empower Plant
+
+Guidance for AI coding agents working in this repo. Read this before making changes,
+and read [`_tda/AGENTS.md`](./_tda/AGENTS.md) before touching anything under `_tda/`.
+
+## What this repo is
+
+Empower Plant is a multi-language/framework **demo** app whose real product is the
+**Sentry data it generates**. The instrumentation (Sentry SDK setup, traces, errors,
+replay, profiling, distributed tracing) is not incidental — it *is* the thing being
+demoed. A change that "works" but quietly alters what shows up in Sentry for the normal
+demo is a regression, even if the app still renders.
+
+- **Frontends:** `react` (primary/default), `angular`, `vue`, `next`.
+- **Backends:** `flask` (default), `flask-otlp`, `express`, `go`, `laravel`,
+  `ruby-on-rails`, `spring-boot`, `spring-boot-otlp`, `aspnetcore`.
+- A frontend picks its backend at runtime via `?backend=` (defaults to `flask`).
+- Demo behavior is driven by stackable URL query params (`?backend=`, `?se=`,
+  `?crash=`, `?rageclick=`, `?userFeedback=`, …) — see the root [README.md](./README.md).
+  When adding behavior keyed on the URL, mirror the existing param patterns in
+  `react/src/index.js`.
+
+## Running locally
+
+The `./deploy` script is the entry point. `--env=local` runs each project's
+`run_local.sh` instead of deploying to GCP:
+
+```
+./deploy --env=local flask                 # backend, prod-like
+./deploy --env=local react -- npm start    # react hot-reload server
+./deploy --env=local react flask laravel   # wires multiple together automatically
+```
+
+First local run creates `local.env` from `.local.env.base`; fill in personal DSNs etc.
+
+## The golden rule: do not regress the default demo flow
+
+The path that runs every day — a normal browser pageload with **no special query
+params** — is the most important one, and it is exactly what the TDA suite exercises in
+production. Any change to a frontend, and **especially any change to Sentry
+instrumentation**, must be shown to leave that default flow unchanged.
+
+When you change instrumentation (init, integrations, trace propagation, sampling,
+tags, fingerprinting, replay/profiling), do **all** of the following and state the
+result explicitly in the PR description — do not assert "should be fine from the code":
+
+1. **Exercise the default flow** (no params): load the app, navigate, trigger the
+   checkout error, and confirm pageload/navigation transactions, errors, Session
+   Replay, profiling, and backend trace propagation still behave as before.
+2. **Exercise the new behavior** you added (e.g. with its query param / entry point).
+3. **Confirm the new behavior is inert when not triggered** — if it's gated on a param
+   or condition, prove the no-param case early-returns and changes nothing.
+
+A reviewer asking "did you test that this doesn't regress the normal flow?" means this
+step was skipped. Bake the answer into the PR up front.
+
+## Test data automation
+
+Anything under `_tda/` (the scheduled Sauce Labs / Appium / Selenium journeys that
+keep demo.sentry.io populated) has its own rules and its own failure modes — a passing
+pytest run there does **not** mean the journey worked. Read
+[`_tda/AGENTS.md`](./_tda/AGENTS.md) before adding or editing tests.

--- a/_tda/AGENTS.md
+++ b/_tda/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md — Test Data Automation (`_tda`)
+
+Guidance for AI coding agents adding or editing TDA tests. The parent
+[`../AGENTS.md`](../AGENTS.md) covers the repo as a whole; this file is specifically
+about how TDA tests really work — and why "the test passed" is almost never enough
+evidence here.
+
+## What TDA is
+
+TDA runs end-to-end user journeys on a schedule to generate realistic errors and
+transactions in `demo.sentry.io`:
+
+- `desktop_web/` — Selenium against **Sauce Labs** browsers (`desktop_web_driver`).
+- `mobile_native/` — Appium against **Sauce Labs** real devices/emulators
+  (`android_flutter_driver`, `android_emu_driver`, `ios_sim_driver`, …).
+
+The driver fixtures live in `conftest.py` and are **Sauce-only** — they connect to
+`ondemand.us-west-1.saucelabs.com` and need `SAUCE_USERNAME` / `SAUCE_ACCESS_KEY`
+(from `.sauce_credentials`).
+
+## ⚠️ Read this before claiming a test passes
+
+These two facts are why a green pytest run is misleading, and are the most common way
+an agent "tests it wrong" here:
+
+### 1. Tests are designed NOT to hard-fail
+
+Almost every test wraps its whole body in:
+
+```python
+try:
+    ...journey...
+except Exception as err:
+    sentry_sdk.capture_exception(err)
+```
+
+A missing element, a broken selector, or a journey that never happened is **swallowed**
+— pytest still exits 0. So **exit code 0 ≠ the journey ran**. Verification means
+confirming the *outcome*, not the return code:
+
+- Open the **Sauce session** (the run prints `sauceLabsUrl`) and watch the video / read
+  the Appium log — confirm each step actually located its element and advanced.
+- Open the **Sentry links** printed at the end of the run (the `GENERATED errors` /
+  discover links keyed on the `se` tag) and confirm the expected errors/transactions/
+  traces actually landed.
+
+Never report a TDA test as passing based on pytest output alone.
+
+### 2. The real environment is Sauce Labs, not your local Appium
+
+Running against a local Appium + UiAutomator2 server is convenient for selector
+discovery but is **not** the prescribed verification — the fixtures don't even use it.
+Verify the way production runs, per the README
+([How to run locally to verify a new test works](./README.md)):
+
+```
+./deploy _tda --env=local -- ./run_local.sh mobile_native/android_flutter/test_x.py
+./deploy _tda --env=local -- ./run_local.sh desktop_web/test_x.py
+```
+
+Then do the Sauce + Sentry confirmation from #1. "Ran it locally on my own Appium" is
+not sufficient evidence for a PR.
+
+### 3. Mobile fixtures install a RELEASED artifact, not your local build
+
+The mobile driver fixtures download the app from a **GitHub Release**, so the test runs
+against published binaries — not whatever is on your machine or in a sibling repo PR.
+For example, `android_flutter_driver` is pinned:
+
+```python
+'appium:app': '.../sentry-demos/flutter/releases/download/1.0.0/flutter-android.apk'
+```
+
+Consequences you must respect:
+
+- A test that drives a screen/feature **not present in that released build** cannot
+  truly pass on Sauce — the element won't exist and (per #1) the failure is swallowed.
+- Before such a test can legitimately go green, **both** must be true: (a) the app
+  feature is shipped in a published release, and (b) the fixture's release/version is
+  bumped to that release. Bumping the version is part of the work, not a follow-up.
+- Do not merge or describe as "passing" a test whose journey isn't in the artifact the
+  fixture actually installs. If you're adding the test ahead of the release, say so
+  explicitly and note it will only verify once the release + version bump land.
+
+## Conventions
+
+- Test **files and functions must be prefixed `test_`** or pytest won't discover them.
+  No registration needed beyond placing the file in the right directory.
+- Find Appium selectors with the Appium Inspector connected to a live Sauce session;
+  match the style of neighboring tests (`AppiumBy.ACCESSIBILITY_ID`,
+  `AppiumBy.ANDROID_UIAUTOMATOR` with `description(...)`, etc.).
+- Leave a short `time.sleep(...)` (or equivalent) before teardown so async
+  transactions/errors flush to Sentry before the session quits.
+- Tune `implicitly_wait` down around optional/conditional dialogs so you don't block the
+  full 20 s when an element is legitimately absent (see
+  `test_checkout_flutter_android.py`).
+- The `se` tag (set per-fixture from `se_prefix`) is how a run's data is found in
+  Sentry — keep it intact.
+
+## Modes
+
+- `config.yaml` → `mode: direct` — production: events ingest straight to
+  `demo.sentry.io`.
+- `config.local.yaml` → `mode: mock` — events captured by the local mini-relay as
+  templates; used with `--env=local`.


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` guidance for AI coding agents — one at the repo root and one in `_tda/` — per @maxkosty's request. They encode the testing/verification expectations that recent agent-authored PRs missed, so future agent work tests changes the right way.

Each file is aligned with a specific recent PR's feedback:

| File | Aligned with | Gap it closes |
|---|---|---|
| `AGENTS.md` (root) | #1555 | *what* to verify — instrumentation IS the product, so any frontend/SDK change must **explicitly** prove the default (no-param) demo flow is unregressed (3-step checklist). |
| `_tda/AGENTS.md` | #1556 | *where/how* to verify — TDA tests swallow exceptions (green pytest ≠ journey ran), the real environment is **Sauce Labs** not local Appium, and mobile fixtures install a **released** GitHub artifact pinned by version. |

## Why

Both came out of "it's not testing it right":
- **#1555** changed Sentry trace instrumentation but didn't explicitly test that the normal browser flow was unchanged.
- **#1556** added TDA tests that "passed" on a local Appium server — but those tests swallow exceptions, weren't run on Sauce, and drove app screens not present in the released APK the fixture installs.

The root file documents the multi-framework demo, local-run via `./deploy`, and the "don't regress the default flow" rule. The `_tda` file documents the Sauce-only fixtures, the swallowed-exception gotcha, the released-artifact requirement, and the conventions (`test_` prefix, selectors, sleeps, `se` tag, direct vs mock modes).

## Notes
- Docs only — no code or test behavior changes.
- No prior `AGENTS.md`/`CLAUDE.md` existed in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
