### PR TITLE
react: migrate to Sentry span streaming

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "application-monitoring",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "~10.47.0",
+        "@sentry/react": "~10.65.0",
         "@statsig/js-client": "^3.15.0",
         "@testing-library/jest-dom": "~5.11.4",
         "@testing-library/react": "~11.1.0",
@@ -3976,56 +3976,6 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "license": "MIT"
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.47.0.tgz",
-      "integrity": "sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.47.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.47.0.tgz",
-      "integrity": "sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.47.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.47.0.tgz",
-      "integrity": "sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.47.0",
-        "@sentry/core": "10.47.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.47.0.tgz",
-      "integrity": "sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.47.0",
-        "@sentry/core": "10.47.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-3.5.0.tgz",
@@ -4037,16 +3987,30 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.47.0.tgz",
-      "integrity": "sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
+      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.47.0",
-        "@sentry-internal/feedback": "10.47.0",
-        "@sentry-internal/replay": "10.47.0",
-        "@sentry-internal/replay-canvas": "10.47.0",
-        "@sentry/core": "10.47.0"
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "@sentry/feedback": "10.65.0",
+        "@sentry/replay": "10.65.0",
+        "@sentry/replay-canvas": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
+      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
@@ -4302,29 +4266,80 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/core": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
-      "integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
+    "node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
+      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
+      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.65.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.47.0.tgz",
-      "integrity": "sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==",
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.65.0.tgz",
+      "integrity": "sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.47.0",
-        "@sentry/core": "10.47.0"
+        "@sentry/browser": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
+      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
+      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.65.0",
+        "@sentry/replay": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/webpack-plugin": {

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "~10.47.0",
+    "@sentry/react": "~10.65.0",
     "@statsig/js-client": "^3.15.0",
     "@testing-library/jest-dom": "~5.11.4",
     "@testing-library/react": "~11.1.0",

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -109,7 +109,10 @@ Sentry.init({
   tracesSampleRate: 1.0,
   tracePropagationTargets: tracingOrigins,
   propagateTraceparent: true, // Sentry <-> OTLP distributed tracing
-  profilesSampleRate: 1.0,
+  // Span streaming uses v2 profiling: profiler runs while sampled root spans
+  // exist. (Legacy `profilesSampleRate` is not compatible with span streaming.)
+  profileSessionSampleRate: 1.0,
+  profileLifecycle: 'trace',
   replaysSessionSampleRate: 1.0,
   debug: true,
   enableLogs: true,
@@ -126,6 +129,10 @@ Sentry.init({
       (integration) => integration.name !== 'Dedupe'
     ),
     // Add custom integrations with options
+    // Enable span streaming: spans are sent individually as they complete
+    // instead of being batched into a transaction. This also implicitly sets
+    // `traceLifecycle: 'stream'`.
+    Sentry.spanStreamingIntegration(),
     Sentry.feedbackIntegration({
       // Additional SDK configuration goes in here, for example:
       colorScheme: 'system',
@@ -245,11 +252,14 @@ class App extends Component {
       'enterprise',
     ][Math.floor(Math.random() * 4)];
     currentScope.setTag('customerType', customerType);
+    // In span streaming mode tags don't apply to spans, only attributes do.
+    currentScope.setAttribute('customerType', customerType);
 
     let se = queryParams.get('se');
     if (se) {
       // Route components (navigation changes) will now have 'se' tag on scope
       currentScope.setTag('se', se);
+      currentScope.setAttribute('se', se);
       // for use in CheckoutForm.js when deciding whether to pre-fill form
       // lasts for as long as the tab is open
       sessionStorage.setItem('se', se);
@@ -259,6 +269,7 @@ class App extends Component {
     let cexp = queryParams.get('cexp');
     if (cexp) {
       currentScope.setTag('cexp', cexp);
+      currentScope.setAttribute('cexp', cexp);
 
       if (cexp === 'products_extremely_slow') {
         PRODUCTS_EXTREMELY_SLOW = true;
@@ -275,9 +286,11 @@ class App extends Component {
       console.log('> frontend-only slowdown: true');
       FRONTEND_SLOWDOWN = true;
       currentScope.setTag('frontendSlowdown', true);
+      currentScope.setAttribute('frontendSlowdown', true);
     } else {
       console.log('> frontend + backend slowdown');
       currentScope.setTag('frontendSlowdown', false);
+      currentScope.setAttribute('frontendSlowdown', false);
     }
 
     if (queryParams.get('api') === 'join') {
@@ -288,9 +301,11 @@ class App extends Component {
       }
       PRODUCTS_API = 'products-join';
       currentScope.setTag('api', 'products-join');
+      currentScope.setAttribute('api', 'products-join');
     } else {
       PRODUCTS_API = 'products';
       currentScope.setTag('api', 'products');
+      currentScope.setAttribute('api', 'products');
     }
 
     if (queryParams.get('rageclick') === 'true') {
@@ -305,6 +320,7 @@ class App extends Component {
     sessionStorage.removeItem('lastErrorEventId');
 
     currentScope.setTag('backendType', backendType);
+    currentScope.setAttribute('backendType', backendType);
 
     const metricScopeAttrs = { backendType };
     if (cexp) {
@@ -331,6 +347,7 @@ class App extends Component {
     if (errorBoundary) {
       ERROR_BOUNDARY = errorBoundary;
       currentScope.setTag('error_boundary', errorBoundary);
+      currentScope.setAttribute('error_boundary', errorBoundary);
     }
 
     // Automatically append `se`, `customerType` and `userEmail` query params to all requests


### PR DESCRIPTION
Switch the React app from transaction-based tracing to span streaming, where spans are sent individually as they complete instead of being batched into a transaction at the end. Done via the Sentry span-streaming-js skill.

> [!NOTE]  
> this was created using this skill: https://github.com/getsentry/sentry-for-ai/blob/main/skills-legacy/sentry-span-streaming-js/SKILL.md

## Changes (`react/`)

- **Upgrade `@sentry/react` `~10.47.0` → `~10.65.0`.** Span streaming APIs (`spanStreamingIntegration`, `withStreamedSpan`) require `>=10.61.0`.
- **Add `Sentry.spanStreamingIntegration()`** to the integrations array. This is the browser way to enable streaming — it implicitly sets `traceLifecycle: 'stream'`.
- **Migrate profiling to v2.** Replaced legacy `profilesSampleRate: 1.0` (deprecated, not compatible with span streaming) with `profileSessionSampleRate: 1.0` + `profileLifecycle: 'trace'`. `browserProfilingIntegration()` was already enabled.
- **Pair each `currentScope.setTag()` with a matching `setAttribute()`.** In streaming mode tags no longer apply to spans — only attributes do. The `setTag` calls are kept because the demo forwards those tags as backend request headers.

No `beforeSendSpan` / `beforeSendTransaction` / `ignoreSpans` existed, so nothing to migrate there.

## Verification

- Confirmed `spanStreamingIntegration`, `withStreamedSpan`, `browserProfilingIntegration` resolve as functions in the installed `10.65.0`.
- `src/index.js` parses cleanly.
- Note: `npm install` requires Node 22 per the repo engine constraint.

At runtime, span envelopes should appear as individual requests with content type `application/vnd.sentry.items.span.v2+json`, and spans should show in the Traces view shortly after they complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing

`./deploy --env=staging react`
https://staging.empower-plant.com/products

### BEFORE
https://demo.sentry.io/explore/traces/trace/5c896fa86e974844873aa48786e250c0/?field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=trace&node=span-9311030defd01561&project=5808623&query=span.name%3A%2Fproducts%20span.op%3Apageload%20backendType%3A%EF%80%8DContains%EF%80%8Dflask%20api%3Aproducts%20trace%3A5c896fa86e974844873aa48786e250c0&source=traces&statsPeriod=1h&targetId=9311030defd01561&timestamp=1784062051
<img width="1387" height="2331" alt="pageload-before" src="https://github.com/user-attachments/assets/8f0d08b7-0a7c-4782-a3aa-9ed887a1066a" />

### AFTER
https://team-se.sentry.io/explore/traces/trace/2f2221296d5b45b4b9f24676e0a21335/?field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=span.op&fov=0%2C26788.499755859375&node=span-ac0fe23c18c6c454&project=4509013380825088&query=span.name%3A%2Fproducts&source=traces&statsPeriod=24h&targetId=ac0fe23c18c6c454&timestamp=1784062571
<img width="1111" height="1743" alt="pageload-after" src="https://github.com/user-attachments/assets/3df647a3-fed4-47e9-932b-8fbf19e6303e" />

