### PR TITLE
tda(cexp): switch critical experiences schedule to 7-day cycle

### DIFF
--- a/_tda/conftest.py
+++ b/_tda/conftest.py
@@ -307,8 +307,13 @@ def cexp(random):
         #d4 = now.hour // 4
         #return 4 if d4 == 5 else d4
 
-        # 5 - 1 - 5 - 1 - 5 - 1 - 5 - 1
-        return (now.hour // 6) * 2 + (0 if now.hour % 6 < 5 else 1)
+        # 24-hour cycle: 5 - 1 - 5 - 1 - 5 - 1 - 5 - 1 (hours normal/broken)
+        #return (now.hour // 6) * 2 + (0 if now.hour % 6 < 5 else 1)
+
+        # 7-day cycle: same 5:1 proportion scaled 7x -> 35 - 7 - 35 - 7 - 35 - 7 - 35 - 7 (hours normal/broken)
+        # 4 blocks of 42 hours (35h healthy + 7h broken) across 168 hours; each broken experience rotates every 1.75 days
+        h = now.weekday() * 24 + now.hour
+        return (h // 42) * 2 + (0 if h % 42 < 35 else 1)
 
     # array length must match number of possible time segments
     probabilities = {       # segments    0    1    2    3    4    5    6    7   


### PR DESCRIPTION
# Goal
Less jagged graphs by virtue of having 7x more samples

# Change
Scale the critical-experiences time-segment pattern from a 24-hour cycle to a 7-day cycle, preserving the same 5:1 healthy-to-broken proportion.

# Rollout plan
Before merging will set dashboard filter to an absolute range of `now, now - 24h` and save for everyone. That way team is not disrupted while we collect first 7d worth of data

Once we have 7d of data set dashboard filter to `Last 7 days` and save for everyone

# Testing
none