### PR TITLE
react: pin checkout 500 error to the page it happens on

### DIFF
--- a/react/src/components/CheckoutForm.jsx
+++ b/react/src/components/CheckoutForm.jsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/react';
 import { connect } from 'react-redux';
 import Loader from 'react-loader-spinner';
 import { countItemsInCart } from '../utils/cart';
-import { getTag } from '../utils/utils';
+import { getTag, withCurrentLocation } from '../utils/utils';
 import { updateStatsigUserAndEvaluate } from '../utils/statsig';
 
 function CheckoutForm({ backend, rageclick, checkout_success, cart }) {
@@ -199,7 +199,7 @@ function CheckoutForm({ backend, rageclick, checkout_success, cart }) {
       try {
         await checkout(cart, span);
       } catch (error) {
-        Sentry.captureException(error);
+        Sentry.captureException(error, withCurrentLocation());
         hadError = true;
       }
       setLoading(false);

--- a/react/src/utils/utils.js
+++ b/react/src/utils/utils.js
@@ -15,7 +15,12 @@ function itemsInCart(cart) {
 // window.location and scope data supplies `transaction` during prepareEvent),
 // so an event captured right before a redirect would otherwise be tagged with
 // the destination page. The location is snapshotted now, at call time, and
-// re-applied via a scope event processor that runs last in the pipeline.
+// re-applied via a scope event processor.
+//
+// This override is deterministic, not a race with httpContext: httpContext sets
+// request.url in the SDK's `preprocessEvent` phase, which runs before ANY event
+// processor, and scope event processors run last of all processors (see
+// @sentry/core `prepareEvent`). So this processor reliably wins.
 function withCurrentLocation() {
     const url = window.location.href;
     const transaction = window.location.pathname;

--- a/react/src/utils/utils.js
+++ b/react/src/utils/utils.js
@@ -8,4 +8,25 @@ function itemsInCart(cart) {
     return Object.values(cart).reduce((a, b) => a + b, 0)
 }
 
-export { getTag, itemsInCart };
+// Returns a captureContext callback (the standard second arg to
+// Sentry.captureException) that pins the event to the page it's called from.
+// In a SPA a subsequent navigate() changes window.location synchronously while
+// Sentry enriches events asynchronously (httpContext sets request.url from
+// window.location and scope data supplies `transaction` during prepareEvent),
+// so an event captured right before a redirect would otherwise be tagged with
+// the destination page. The location is snapshotted now, at call time, and
+// re-applied via a scope event processor that runs last in the pipeline.
+function withCurrentLocation() {
+    const url = window.location.href;
+    const transaction = window.location.pathname;
+    return (scope) => {
+        scope.addEventProcessor((event) => {
+            event.request = { ...event.request, url };
+            event.transaction = transaction;
+            return event;
+        });
+        return scope;
+    };
+}
+
+export { getTag, itemsInCart, withCurrentLocation };


### PR DESCRIPTION
## Problem

FRONTEND-REACT-715's `url` tag was split across `/checkout-form`, `/cart`, and `/error`. The checkout 500 is captured right before `navigate('/error')`; React Router changes `window.location` synchronously while the SDK enriches events asynchronously, so events were tagged with the redirect destination instead of `/checkout-form` where the error actually happens.

<img width="531" height="280" alt="Screenshot 2026-07-22 at 9 28 14 PM" src="https://github.com/user-attachments/assets/21e71f82-a56b-4da9-85d0-7bb2e453caa8" />

## Change

Add `withCurrentLocation()` in `react/src/utils/utils.js` — it snapshots the location synchronously and returns a `captureContext` callback that re-applies `url`/`transaction` via a scope event processor (runs last in the enrichment pipeline). `CheckoutForm` passes it as the standard second arg:

```js
Sentry.captureException(error, withCurrentLocation());
```

See the code comment on `withCurrentLocation()` for the details.

## Testing

Tested manually via `./deploy --env=local react`, exercising the checkout error flow and confirming the app runs and the error is captured on the checkout-form page.
